### PR TITLE
Refactor orderitem struct

### DIFF
--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -174,9 +174,6 @@ func (db *MongoDatabase) PutObject(hash common.Hash, val interface{}) error {
 		// PutObject order into ordersCollection collection
 		// Store the key
 		o := val.(*tomox_state.OrderItem)
-		if len(o.Key) == 0 {
-			o.Key = cacheKey
-		}
 		if err := db.CommitOrder(o); err != nil {
 			log.Error(err.Error())
 			return err

--- a/tomox/order.go
+++ b/tomox/order.go
@@ -1,59 +1,10 @@
 package tomox
 
-import (
-	"fmt"
-	"github.com/tomochain/tomochain/tomox/tomox_state"
-	"math/big"
-	"time"
-)
-
 const (
 	OrderStatusNew           = "NEW"
 	OrderStatusOpen          = "OPEN"
 	OrderStatusPartialFilled = "PARTIAL_FILLED"
 	OrderStatusFilled        = "FILLED"
 	OrderStatusCancelled     = "CANCELLED"
-	OrderStatusRejected 	= "REJECTED"
+	OrderStatusRejected      = "REJECTED"
 )
-
-
-type SignatureRecord struct {
-	V byte   `json:"V" bson:"V"`
-	R string `json:"R" bson:"R"`
-	S string `json:"S" bson:"S"`
-}
-
-type OrderItemBSON struct {
-	Quantity        string           `json:"quantity,omitempty" bson:"quantity"`
-	Price           string           `json:"price,omitempty" bson:"price"`
-	ExchangeAddress string           `json:"exchangeAddress,omitempty" bson:"exchangeAddress"`
-	UserAddress     string           `json:"userAddress,omitempty" bson:"userAddress"`
-	BaseToken       string           `json:"baseToken,omitempty" bson:"baseToken"`
-	QuoteToken      string           `json:"quoteToken,omitempty" bson:"quoteToken"`
-	Status          string           `json:"status,omitempty" bson:"status"`
-	Side            string           `json:"side,omitempty" bson:"side"`
-	Type            string           `json:"type,omitempty" bson:"type"`
-	Hash            string           `json:"hash,omitempty" bson:"hash"`
-	Signature       *SignatureRecord `json:"signature,omitempty" bson:"signature"`
-	FilledAmount    string           `json:"filledAmount,omitempty" bson:"filledAmount"`
-	Nonce           string           `json:"nonce,omitempty" bson:"nonce"`
-	PairName        string           `json:"pairName,omitempty" bson:"pairName"`
-	CreatedAt       time.Time        `json:"createdAt,omitempty" bson:"createdAt"`
-	UpdatedAt       time.Time        `json:"updatedAt,omitempty" bson:"updatedAt"`
-	OrderID         string           `json:"orderID,omitempty" bson:"orderID"`
-	NextOrder       string           `json:"nextOrder,omitempty" bson:"nextOrder"`
-	PrevOrder       string           `json:"prevOrder,omitempty" bson:"prevOrder"`
-	OrderList       string           `json:"orderList,omitempty" bson:"orderList"`
-	Key             string           `json:"key" bson:"key"`
-}
-
-type Order struct {
-	Item *tomox_state.OrderItem
-	Key  []byte `json:"orderID"`
-}
-
-func (order *Order) String() string {
-
-	return fmt.Sprintf("orderID : %s, price: %s, quantity :%s, relayerID: %s",
-		new(big.Int).SetBytes(order.Key), order.Item.Price, order.Item.Quantity, order.Item.ExchangeAddress.Hex())
-}

--- a/tomox/tomox_state/orderitem.go
+++ b/tomox/tomox_state/orderitem.go
@@ -34,11 +34,7 @@ type OrderItem struct {
 	CreatedAt       time.Time      `json:"createdAt,omitempty"`
 	UpdatedAt       time.Time      `json:"updatedAt,omitempty"`
 	OrderID         uint64         `json:"orderID,omitempty"`
-	// *OrderMeta
-	NextOrder []byte `json:"-"`
-	PrevOrder []byte `json:"-"`
-	OrderList []byte `json:"-"`
-	Key       string `json:"key"`
+	ExtraData       string         `json:"extraData,omitempty"`
 }
 
 // Signature struct
@@ -73,10 +69,7 @@ type OrderItemBSON struct {
 	CreatedAt       time.Time        `json:"createdAt,omitempty" bson:"createdAt"`
 	UpdatedAt       time.Time        `json:"updatedAt,omitempty" bson:"updatedAt"`
 	OrderID         string           `json:"orderID,omitempty" bson:"orderID"`
-	NextOrder       string           `json:"nextOrder,omitempty" bson:"nextOrder"`
-	PrevOrder       string           `json:"prevOrder,omitempty" bson:"prevOrder"`
-	OrderList       string           `json:"orderList,omitempty" bson:"orderList"`
-	Key             string           `json:"key" bson:"key"`
+	ExtraData       string           `json:"extraData,omitempty" bson:"extraData"`
 }
 
 func (o *OrderItem) GetBSON() (interface{}, error) {
@@ -97,7 +90,7 @@ func (o *OrderItem) GetBSON() (interface{}, error) {
 		CreatedAt:       o.CreatedAt,
 		UpdatedAt:       o.UpdatedAt,
 		OrderID:         strconv.FormatUint(o.OrderID, 10),
-		Key:             o.Key,
+		ExtraData:       o.ExtraData,
 	}
 
 	if o.FilledAmount != nil {
@@ -138,7 +131,7 @@ func (o *OrderItem) SetBSON(raw bson.Raw) error {
 		CreatedAt       time.Time        `json:"createdAt" bson:"createdAt"`
 		UpdatedAt       time.Time        `json:"updatedAt" bson:"updatedAt"`
 		OrderID         string           `json:"orderID" bson:"orderID"`
-		Key             string           `json:"key" bson:"key"`
+		ExtraData       string           `json:"extraData,omitempty" bson:"extraData"`
 	})
 
 	err := raw.Unmarshal(decoded)
@@ -186,8 +179,7 @@ func (o *OrderItem) SetBSON(raw bson.Raw) error {
 		return err
 	}
 	o.OrderID = uint64(orderID)
-	o.Key = decoded.Key
-
+	o.ExtraData = decoded.ExtraData
 	return nil
 }
 


### PR DESCRIPTION
**Change in this PR:**
- Remove unused fields of orderItem: `key`, `NextOrder`, `PreOrder`, `OrderList`
- Add `ExtraData` : for any addition data, we can encode JSON and put to this field
![image](https://user-images.githubusercontent.com/17243442/69520213-9ce13900-0f8e-11ea-8669-3eff0089db64.png)

**Note** This change requires hard fork (or reset chain from the beginning)