### PR TITLE
[Fix] avoid side-effect of using balance variable

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -632,7 +632,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			minGasPrice = common.TRC21GasPrice
 		}
 	}
-	if balance.Add(balance, feeCapacity).Cmp(cost) < 0 {
+	if new(big.Int).Add(balance, feeCapacity).Cmp(cost) < 0 {
 		return ErrInsufficientFunds
 	}
 


### PR DESCRIPTION
```
balance.Add(balance, feeCapacity).Cmp(cost)
```
would change **balance** variable, this is unnecessary and would cause further issue if continuing using **balance**