### PR TITLE
Refactor syncDataToSDKNode

### DIFF
--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -375,6 +375,14 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 		}
 	}
 
+	// update status for Market orders
+	if updatedTakerOrder.Type == tomox_state.Market {
+		if updatedTakerOrder.FilledAmount.Cmp(big.NewInt(0)) > 0 {
+			updatedTakerOrder.Status = OrderStatusFilled
+		} else {
+			updatedTakerOrder.Status = OrderStatusRejected
+		}
+	}
 	log.Debug("PutObject processed takerOrder",
 		"pairName", updatedTakerOrder.PairName, "userAddr", updatedTakerOrder.UserAddress.Hex(), "side", updatedTakerOrder.Side,
 		"price", updatedTakerOrder.Price, "quantity", updatedTakerOrder.Quantity, "filledAmount", updatedTakerOrder.FilledAmount, "status", updatedTakerOrder.Status,

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -430,6 +430,8 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 				tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.Hash, txHash, orderHistoryRecord)
 
 				updatedTakerOrder.Status = OrderStatusRejected
+				updatedTakerOrder.TxHash = txHash
+				updatedTakerOrder.UpdatedAt = txMatchTime
 				if err := db.PutObject(updatedTakerOrder.Hash, updatedTakerOrder); err != nil {
 					return fmt.Errorf("SDKNode: failed to reject takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
 				}
@@ -450,6 +452,8 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 			tomox.UpdateOrderCache(order.BaseToken, order.QuoteToken, order.Hash, txHash, orderHistoryRecord)
 
 			order.Status = OrderStatusRejected
+			order.TxHash = txHash
+			order.UpdatedAt = txMatchTime
 			if err = db.PutObject(order.Hash, order); err != nil {
 				return fmt.Errorf("SDKNode: failed to update rejectedOder to sdkNode %s", err.Error())
 			}

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -450,7 +450,10 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 				Status:       order.Status,
 			}
 			tomox.UpdateOrderCache(order.BaseToken, order.QuoteToken, order.Hash, txHash, orderHistoryRecord)
-
+			dirtyFilledAmount, ok := makerDirtyFilledAmount[order.Hash.Hex()]
+			if ok && dirtyFilledAmount != nil {
+				order.FilledAmount.Add(order.FilledAmount, dirtyFilledAmount)
+			}
 			order.Status = OrderStatusRejected
 			order.TxHash = txHash
 			order.UpdatedAt = txMatchTime

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -510,6 +510,8 @@ func (tomox *TomoX) UpdateOrderCache(baseToken, quoteToken common.Address, order
 
 func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 	db := tomox.GetMongoDB()
+	defer tomox.orderCache.Remove(txhash)
+
 	for _, order := range db.GetOrderByTxHash(txhash) {
 		c, ok := tomox.orderCache.Get(txhash)
 		log.Debug("Tomox reorg: rollback order", "txhash", txhash.Hex(), "order", tomox_state.ToJSON(order), "orderHistoryItem", c)

--- a/tomox/tomox_state/common.go
+++ b/tomox/tomox_state/common.go
@@ -3,10 +3,8 @@ package tomox_state
 import (
 	"encoding/json"
 	"errors"
-	"math/big"
-	"strconv"
-
 	"github.com/tomochain/tomochain/crypto"
+	"math/big"
 
 	"github.com/tomochain/tomochain/common"
 )
@@ -129,9 +127,12 @@ func DecodeTxMatchesBatch(data []byte) (TxMatchBatch, error) {
 	return txMatchResult, nil
 }
 
-func GetOrderHistoryKey(baseToken, quoteToken common.Address, orderId uint64) common.Hash {
-	return crypto.Keccak256Hash(baseToken.Bytes(), quoteToken.Bytes(), []byte(strconv.FormatUint(orderId, 10)))
+// use orderHash instead of orderId
+// because both takerOrders don't have orderId
+func GetOrderHistoryKey(baseToken, quoteToken common.Address, orderHash common.Hash) common.Hash {
+	return crypto.Keccak256Hash(baseToken.Bytes(), quoteToken.Bytes(), orderHash.Bytes())
 }
+
 func (tx TxDataMatch) DecodeOrder() (*OrderItem, error) {
 	order := &OrderItem{}
 	if err := DecodeBytesItem(tx.Order, order); err != nil {


### PR DESCRIPTION
**Change in this PR:**

- Update orderCacheKey 3d9de67
- Remove orderCache of reorgTx 64f81fa
- update `txHash`, `updatedAt` of rejectedOrder e29985d
- fix #48: update filledAmount of rejectedMakerOrder 5cbdd56
- update status of market orders: ce27bede8d9d4df8a76b6e069924ccd177df76a6
  - filledAmount > 0: `FILLED`
  - filledAmount = 0 : `REJECTED`