### PR TITLE
Tomox reorg: rollback order.updatedAt

### DIFF
--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -279,6 +279,7 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 			TxHash:       originTakerOrder.TxHash,
 			FilledAmount: tomox_state.CloneBigInt(originTakerOrder.FilledAmount),
 			Status:       originTakerOrder.Status,
+			UpdatedAt:    originTakerOrder.UpdatedAt,
 		}
 	}
 	if originTakerOrder != nil {
@@ -406,6 +407,7 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 			TxHash:       o.TxHash,
 			FilledAmount: tomox_state.CloneBigInt(o.FilledAmount),
 			Status:       o.Status,
+			UpdatedAt:    o.UpdatedAt,
 		}
 		tomox.UpdateOrderCache(o.BaseToken, o.QuoteToken, o.Hash, txHash, lastState)
 		o.TxHash = txHash
@@ -439,6 +441,7 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 					TxHash:       updatedTakerOrder.TxHash,
 					FilledAmount: tomox_state.CloneBigInt(updatedTakerOrder.FilledAmount),
 					Status:       updatedTakerOrder.Status,
+					UpdatedAt:    updatedTakerOrder.UpdatedAt,
 				}
 				tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.Hash, txHash, orderHistoryRecord)
 
@@ -461,6 +464,7 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tomox_state.OrderItem, txH
 				TxHash:       order.TxHash,
 				FilledAmount: tomox_state.CloneBigInt(order.FilledAmount),
 				Status:       order.Status,
+				UpdatedAt:    order.UpdatedAt,
 			}
 			tomox.UpdateOrderCache(order.BaseToken, order.QuoteToken, order.Hash, txHash, orderHistoryRecord)
 			dirtyFilledAmount, ok := makerDirtyFilledAmount[order.Hash.Hex()]
@@ -554,6 +558,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 		order.TxHash = orderHistoryItem.TxHash
 		order.Status = orderHistoryItem.Status
 		order.FilledAmount = tomox_state.CloneBigInt(orderHistoryItem.FilledAmount)
+		order.UpdatedAt = orderHistoryItem.UpdatedAt
 		log.Debug("Tomox reorg: update order to the last orderHistoryItem", "order", tomox_state.ToJSON(order), "orderHistoryItem", orderHistoryItem)
 		if err := db.PutObject(order.Hash, order); err != nil {
 			log.Error("SDKNode: failed to update reorg order", "err", err.Error(), "order", tomox_state.ToJSON(order))

--- a/tomox/tomox_state/common.go
+++ b/tomox/tomox_state/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/tomochain/tomochain/crypto"
 	"math/big"
+	"time"
 
 	"github.com/tomochain/tomochain/common"
 )
@@ -39,13 +40,13 @@ var EmptyOrder = OrderItem{
 }
 
 var (
-	ErrInvalidSignature      = errors.New("verify order: invalid signature")
-	ErrInvalidPrice          = errors.New("verify order: invalid price")
-	ErrInvalidQuantity       = errors.New("verify order: invalid quantity")
-	ErrInvalidRelayer        = errors.New("verify order: invalid relayer")
-	ErrInvalidOrderType      = errors.New("verify order: unsupported order type")
-	ErrInvalidOrderSide      = errors.New("verify order: invalid order side")
-	ErrInvalidStatus         = errors.New("verify order: invalid status")
+	ErrInvalidSignature = errors.New("verify order: invalid signature")
+	ErrInvalidPrice     = errors.New("verify order: invalid price")
+	ErrInvalidQuantity  = errors.New("verify order: invalid quantity")
+	ErrInvalidRelayer   = errors.New("verify order: invalid relayer")
+	ErrInvalidOrderType = errors.New("verify order: unsupported order type")
+	ErrInvalidOrderSide = errors.New("verify order: invalid order side")
+	ErrInvalidStatus    = errors.New("verify order: invalid status")
 
 	// supported order types
 	MatchingOrderType = map[string]bool{
@@ -97,7 +98,7 @@ var (
 )
 
 type TxDataMatch struct {
-	Order         []byte // serialized data of order has been processed in this tx
+	Order []byte // serialized data of order has been processed in this tx
 }
 
 type TxMatchBatch struct {
@@ -107,7 +108,7 @@ type TxMatchBatch struct {
 }
 
 type MatchingResult struct {
-	Trades []map[string]string
+	Trades  []map[string]string
 	Rejects []*OrderItem
 }
 
@@ -145,6 +146,7 @@ type OrderHistoryItem struct {
 	TxHash       common.Hash
 	FilledAmount *big.Int
 	Status       string
+	UpdatedAt    time.Time
 }
 
 // use alloc to prevent reference manipulation


### PR DESCRIPTION
We compare `order.updatedAt` and `txTimestamp` to make sure not to override orders of old txs.
In case of `reorg`, we should rollback `order.updatedAt`

This is one of reasons causing #47 