### PR TITLE
[TomoX]  index orders.txHash, trades.txHash

### DIFF
--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -318,6 +318,14 @@ func (db *MongoDatabase) EnsureIndexes() error {
 		Sparse:     true,
 		Name:       "index_order_hash",
 	}
+	orderTxHashIndex := mgo.Index{
+		Key:        []string{"txHash"},
+		Unique:     true,
+		DropDups:   true,
+		Background: true,
+		Sparse:     true,
+		Name:       "index_order_tx_hash",
+	}
 	tradeHashIndex := mgo.Index{
 		Key:        []string{"hash"},
 		Unique:     true,
@@ -326,13 +334,27 @@ func (db *MongoDatabase) EnsureIndexes() error {
 		Sparse:     true,
 		Name:       "index_trade_hash",
 	}
+	tradeTxHashIndex := mgo.Index{
+		Key:        []string{"txHash"},
+		Unique:     true,
+		DropDups:   true,
+		Background: true,
+		Sparse:     true,
+		Name:       "index_trade_tx_hash",
+	}
 	sc := db.Session.Copy()
 	defer sc.Close()
 	if err := sc.DB(db.dbName).C(ordersCollection).EnsureIndex(orderHashIndex); err != nil {
 		return fmt.Errorf("failed to index orders.hash . Err: %v", err)
 	}
+	if err := sc.DB(db.dbName).C(ordersCollection).EnsureIndex(orderTxHashIndex); err != nil {
+		return fmt.Errorf("failed to index orders.txHash . Err: %v", err)
+	}
 	if err := sc.DB(db.dbName).C(tradesCollection).EnsureIndex(tradeHashIndex); err != nil {
 		return fmt.Errorf("failed to index trades.hash . Err: %v", err)
+	}
+	if err := sc.DB(db.dbName).C(tradesCollection).EnsureIndex(tradeTxHashIndex); err != nil {
+		return fmt.Errorf("failed to index trades.txHash . Err: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
In case of reorg, we look up orders, trades by txHash
https://github.com/tomochain/tomochain/blob/master/tomox/tomox.go#L539
https://github.com/tomochain/tomochain/blob/master/tomox/tomox.go#L568
This change speeds up that process