### PR TITLE
keep trades, rejects cache for reorg

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2285,22 +2285,18 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 				log.Error("SDK node decode takerOrderInTx failed", "txDataMatch", txMatch)
 				return
 			}
-
+			cacheKey := crypto.Keccak256Hash(txMatchBatch.TxHash.Bytes(), takerOrderInTx.Hash.Bytes())
 			// getTrades from cache
-			resultTrades, ok := bc.resultTrade.Get(crypto.Keccak256Hash(txMatchBatch.TxHash.Bytes(), takerOrderInTx.Hash.Bytes()))
+			resultTrades, ok := bc.resultTrade.Get(cacheKey)
 			if ok && resultTrades != nil {
 				trades = resultTrades.([]map[string]string)
 			}
-			// remove from cache
-			bc.resultTrade.Remove(crypto.Keccak256Hash(txMatchBatch.TxHash.Bytes(), takerOrderInTx.Hash.Bytes()))
 
 			// getRejectedOrder from cache
-			rejected, ok := bc.rejectedOrders.Get(crypto.Keccak256Hash(txMatchBatch.TxHash.Bytes(), takerOrderInTx.Hash.Bytes()))
+			rejected, ok := bc.rejectedOrders.Get(cacheKey)
 			if ok && rejected != nil {
 				rejectedOrders = rejected.([]*tomox_state.OrderItem)
 			}
-			// remove from cache
-			bc.rejectedOrders.Remove(crypto.Keccak256Hash(txMatchBatch.TxHash.Bytes(), takerOrderInTx.Hash.Bytes()))
 
 			// the smallest time unit in mongodb is millisecond
 			// hence, we should update time in millisecond
@@ -2345,7 +2341,8 @@ func (bc *BlockChain) reorgTxMatches(deletedTxs types.Transactions, newChain typ
 
 func (bc *BlockChain) AddMatchingResult(txHash common.Hash, matchingResults map[common.Hash]tomox_state.MatchingResult) {
 	for hash, result := range matchingResults {
-		bc.resultTrade.Add(crypto.Keccak256Hash(txHash.Bytes(), hash.Bytes()), result.Trades)
-		bc.rejectedOrders.Add(crypto.Keccak256Hash(txHash.Bytes(), hash.Bytes()), result.Rejects)
+		cacheKey := crypto.Keccak256Hash(txHash.Bytes(), hash.Bytes())
+		bc.resultTrade.Add(cacheKey, result.Trades)
+		bc.rejectedOrders.Add(cacheKey, result.Rejects)
 	}
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -538,7 +538,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 
 	for _, order := range db.GetOrderByTxHash(txhash) {
 		c, ok := tomox.orderCache.Get(txhash)
-		log.Debug("Tomox reorg: rollback order", "txhash", txhash.Hex(), "order", tomox_state.ToJSON(order), "orderHistoryItem", c)
+		log.Debug("Tomox reorg: rollback order", "txhash", txhash.Hex(), "order", tomox_state.ToJSON(order))
 		if !ok {
 			log.Debug("Tomox reorg: remove order due to no orderCache", "order", tomox_state.ToJSON(order))
 			if err := db.DeleteObject(order.Hash); err != nil {
@@ -559,7 +559,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 		order.Status = orderHistoryItem.Status
 		order.FilledAmount = tomox_state.CloneBigInt(orderHistoryItem.FilledAmount)
 		order.UpdatedAt = orderHistoryItem.UpdatedAt
-		log.Debug("Tomox reorg: update order to the last orderHistoryItem", "order", tomox_state.ToJSON(order), "orderHistoryItem", orderHistoryItem)
+		log.Debug("Tomox reorg: update order to the last orderHistoryItem", "order", tomox_state.ToJSON(order), "orderHistoryItem", tomox_state.ToJSON(orderHistoryItem))
 		if err := db.PutObject(order.Hash, order); err != nil {
 			log.Error("SDKNode: failed to update reorg order", "err", err.Error(), "order", tomox_state.ToJSON(order))
 		}


### PR DESCRIPTION
1 tx may exist in both sideChain and canonicalChain.
Removing cache `bc.resultTrade`, `bc.rejectedOrders` after SyncDataToSDKNode may cause loosing trades, rejectedOrder data in case of reorg