### PR TITLE
tomoxlending: update lendingItem, lendingTrade timestamp

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -144,7 +144,7 @@ func (v *BlockValidator) ValidateTradingOrder(statedb *state.StateDB, tomoxState
 	return nil
 }
 
-func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address) error {
+func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, blockTime uint64) error {
 	posvEngine, ok := v.bc.Engine().(*posv.Posv)
 	if posvEngine == nil || !ok {
 		return ErrNotPoSV
@@ -167,7 +167,7 @@ func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingSta
 			return fmt.Errorf("invalid lendingItem . Error: %v", err)
 		}
 		// process Matching Engine
-		newTrades, newRejectedOrders, err := lendingService.ApplyOrder(uint64(batch.Timestamp), coinbase, v.bc, statedb, lendingStateDb, tomoxStatedb, lendingstate.GetLendingOrderBookHash(l.LendingToken, l.Term), l)
+		newTrades, newRejectedOrders, err := lendingService.ApplyOrder(blockTime, coinbase, v.bc, statedb, lendingStateDb, tomoxStatedb, lendingstate.GetLendingOrderBookHash(l.LendingToken, l.Term), l)
 		if err != nil {
 			return err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1549,7 +1549,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				}
 				for _, batch := range batches {
 					log.Debug("Verify matching transaction", "txHash", batch.TxHash.Hex())
-					err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author)
+					err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author, block.Time().Uint64())
 					if err != nil {
 						bc.reportBlock(block, nil, err)
 						return i, events, coalescedLogs, err
@@ -1816,7 +1816,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 			}
 			for _, batch := range batches {
 				log.Debug("Lending Verify matching transaction", "txHash", batch.TxHash.Hex())
-				err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tomoxState, batch, author)
+				err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tomoxState, batch, author, block.Time().Uint64())
 				if err != nil {
 					bc.reportBlock(block, nil, err)
 					return nil, err

--- a/core/types.go
+++ b/core/types.go
@@ -40,7 +40,7 @@ type Validator interface {
 
 	ValidateTradingOrder(statedb *state.StateDB, tomoxStatedb *tradingstate.TradingStateDB, txMatchBatch tradingstate.TxMatchBatch, coinbase common.Address) error
 
-	ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address) error
+	ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, blockTime uint64) error
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -706,7 +706,7 @@ func (self *worker) commitNewWork() {
 					// lending transaction
 					lendingBatch := &lendingstate.TxLendingBatch{
 						Data:      lendingInput,
-						Timestamp: int64(header.Time.Uint64()),
+						Timestamp: time.Now().UnixNano(),
 						TxHash:    common.Hash{},
 					}
 					lendingDataBytes, err := lendingstate.EncodeTxLendingBatch(*lendingBatch)


### PR DESCRIPTION
- **blockTime**(in second): the time when masternodes start the mining process, used to processLiquidation
- **txLendingMatch.Timestamp** (in millisecond): the time when masternodes finishes lending matching engine, used to update createdAt, updatedAt of lendingItem, lendingTrade in MongoDB for SDK full node

https://github.com/tomochain/tomochain/pull/111 fixed BAD BLOCK issue but it causes invalid timestamp in MongoDB 
(because timestamp should be in millisecond)