### PR TITLE
tomoxlending: M1 verify orders before running matching engine

### DIFF
--- a/tomoxlending/tomoxlending.go
+++ b/tomoxlending/tomoxlending.go
@@ -136,6 +136,12 @@ func (l *Lending) ProcessOrderPending(createdBlockTime uint64, coinbase common.A
 				S: common.BigToHash(S),
 			},
 		}
+		// make sure order is valid before running matching engine
+		if err := order.VerifyLendingItem(statedb); err != nil {
+			log.Error("tomoxlending processOrderPending: invalid order", "err", err)
+			continue
+		}
+
 		cancel := false
 		if order.Status == lendingstate.LendingStatusCancelled {
 			cancel = true


### PR DESCRIPTION
Relating https://github.com/tomochain/tomochain/pull/122
