### PR TITLE
tomox: add failed order to block

### DIFF
--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -188,12 +188,6 @@ func (tomox *TomoX) ProcessOrderPending(coinbase common.Address, chain consensus
 			},
 			PairName: tx.PairName(),
 		}
-		// make sure order is valid before running matching engine
-		if err := order.VerifyOrder(statedb); err != nil {
-			log.Debug("tomox processOrderPending: invalid order", "err", err, "order", tomox_state.ToJSON(order))
-			txs.Shift()
-			continue
-		}
 		cancel := false
 		if order.Status == OrderStatusCancelled {
 			cancel = true


### PR DESCRIPTION
Validate order in front of the pool only. 
When masternode grasp orders from pool to create block, we always add them to block even it is executed failed