### PR TITLE
tomoxlending: update getCollateralPrice

### DIFF
--- a/tomoxlending/order_processor.go
+++ b/tomoxlending/order_processor.go
@@ -896,9 +896,10 @@ func (l *Lending) GetCollateralPrices(chain consensus.ChainContext, statedb *sta
 			if err != nil {
 				return nil, nil, err
 			}
-			collateralPrice = collateralPrice.Mul(collateralPrice, lendingTokenDecimal)
-			collateralPrice = new(big.Int).Div(collateralTOMOPrice, lendTokenTOMOPrice)
-			log.Debug("GetCollateralPrices: Calculate collateral/LendToken price from collateral/TOMO, lendToken/TOMO", "collateralPrice", collateralPrice)
+			collateralPrice = new(big.Int).Mul(collateralTOMOPrice, lendingTokenDecimal)
+			collateralPrice = new(big.Int).Div(collateralPrice, lendTokenTOMOPrice)
+			log.Debug("GetCollateralPrices: Calculate collateral/LendToken price from collateral/TOMO, lendToken/TOMO", "collateralPrice", collateralPrice,
+				"collateralTOMOPrice", collateralTOMOPrice, "lendingTokenDecimal", lendingTokenDecimal, "lendTokenTOMOPrice", lendTokenTOMOPrice)
 		}
 	}
 


### PR DESCRIPTION
Description:
In case that lendingToken and collateralToken has direct pair in tomox trading, it's OK
If lendingToken and collateralToken doesn't have direct pair but we have lendingToken/TOMO, collateralToken/TOMO. Now, collateralPrice = 0 by a mistake

This PR is going to fix that issue

Testing: 
- Place orders for these pairs in TomoX trading: TOMO/BTC, ETH/TOMO
- Place a lending order with below information:
  - Side: Borrow
  - LendingToken: BTC
  - CollateralToken: ETH

Expect no error thrown

----------------------- 
tomoxlending: update getCollateralPrice
(This content is created via [Gittool](https://github.com/thanhnguyennguyen/lazy/tree/master/git)) 
 On behalf of [thanhnguyennguyen](https://github.com/thanhnguyennguyen)