### PR TITLE
core auto recall

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -59,6 +59,7 @@ var TRC21GasPriceBefore = big.NewInt(2500)
 var TRC21GasPrice = big.NewInt(250000000)
 var RateTopUp = big.NewInt(90) // 90%
 var BaseTopUp = big.NewInt(100)
+var BaseRecall = big.NewInt(100)
 var Blacklist = map[Address]bool{
 	HexToAddress("0x5248bfb72fd4f234e062d3e9bb76f08643004fcd"): true,
 	HexToAddress("0x5ac26105b35ea8935be382863a70281ec7a985e9"): true,

--- a/consensus/posv/posv.go
+++ b/consensus/posv/posv.go
@@ -85,7 +85,7 @@ type LendingService interface {
 	GetTriegc() *prque.Prque
 	ApplyOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error)
 	GetCollateralPrices(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error)
-	ProcessLiquidationData(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (finalizedTrades map[common.Hash]*lendingstate.LendingTrade, err error)
+	ProcessLiquidationData(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (updatedTrades map[common.Hash]*lendingstate.LendingTrade, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*lendingstate.LendingTrade, err error)
 	SyncDataToSDKNode(takerOrderInTx *lendingstate.LendingItem, txHash common.Hash, txMatchTime time.Time, trades []*lendingstate.LendingTrade, rejectedOrders []*lendingstate.LendingItem, dirtyOrderCount *uint64) error
 	UpdateLiquidatedTrade(result lendingstate.FinalizedResult, trades map[common.Hash]*lendingstate.LendingTrade) error
 	RollbackLendingData(txhash common.Hash) error

--- a/consensus/posv/posv.go
+++ b/consensus/posv/posv.go
@@ -83,9 +83,9 @@ type LendingService interface {
 	HasLendingState(block *types.Block) bool
 	GetStateCache() lendingstate.Database
 	GetTriegc() *prque.Prque
-	ApplyOrder(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error)
-	GetCollateralPrices(chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error)
-	ProcessLiquidationData(chain consensus.ChainContext, time *big.Int, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (finalizedTrades map[common.Hash]*lendingstate.LendingTrade, err error)
+	ApplyOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error)
+	GetCollateralPrices(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error)
+	ProcessLiquidationData(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (finalizedTrades map[common.Hash]*lendingstate.LendingTrade, err error)
 	SyncDataToSDKNode(takerOrderInTx *lendingstate.LendingItem, txHash common.Hash, txMatchTime time.Time, trades []*lendingstate.LendingTrade, rejectedOrders []*lendingstate.LendingItem, dirtyOrderCount *uint64) error
 	UpdateLiquidatedTrade(result lendingstate.FinalizedResult, trades map[common.Hash]*lendingstate.LendingTrade) error
 	RollbackLendingData(txhash common.Hash) error

--- a/contracts/tomox/simulation/constants.go
+++ b/contracts/tomox/simulation/constants.go
@@ -29,7 +29,8 @@ var (
 	CollateralRecallRate      = big.NewInt(200)
 	TradeFee                  = uint16(10)  // trade fee decimals 10
 	LendingTradeFee           = uint16(100) // lending trade fee decimals 10
-
+	// 1m , 1d,7d,30d
+	Terms                 = []*big.Int{big.NewInt(60), big.NewInt(86400), big.NewInt(7 * 86400), big.NewInt(30 * 86400)}
 	RelayerCoinbaseKey, _ = crypto.HexToECDSA(os.Getenv("RELAYER_COINBASE_KEY")) //
 	RelayerCoinbaseAddr   = crypto.PubkeyToAddress(RelayerCoinbaseKey.PublicKey) // 0x0D3ab14BBaD3D99F4203bd7a11aCB94882050E7e
 

--- a/contracts/tomox/simulation/deploy/main.go
+++ b/contracts/tomox/simulation/deploy/main.go
@@ -145,34 +145,16 @@ func main() {
 	}
 
 	// add term 1 minute for testing
-	nonce = nonce + 1
-	lendingRelayerRegistration.TransactOpts.Nonce = big.NewInt(int64(nonce))
-	_, err = lendingRelayerRegistration.AddTerm(big.NewInt(60))
-	if err != nil {
-		log.Fatal("Lending add terms", err)
+	for i := 0; i < len(simulation.Terms); i++ {
+		nonce = nonce + 1
+		lendingRelayerRegistration.TransactOpts.Nonce = big.NewInt(int64(nonce))
+		_, err = lendingRelayerRegistration.AddTerm(simulation.Terms[i])
+		if err != nil {
+			log.Fatal("Lending add terms", err)
+		}
+		fmt.Println("wait 2s to add term lending lending contract", simulation.Terms[i])
+		time.Sleep(2 * time.Second)
 	}
-
-	nonce = nonce + 1
-	lendingRelayerRegistration.TransactOpts.Nonce = big.NewInt(int64(nonce))
-	_, err = lendingRelayerRegistration.AddTerm(big.NewInt(86400))
-	if err != nil {
-		log.Fatal("Lending add terms", err)
-	}
-
-	nonce = nonce + 1
-	lendingRelayerRegistration.TransactOpts.Nonce = big.NewInt(int64(nonce))
-	_, err = lendingRelayerRegistration.AddTerm(big.NewInt(7 * 86400))
-	if err != nil {
-		log.Fatal("Lending add terms", err)
-	}
-
-	nonce = nonce + 1
-	lendingRelayerRegistration.TransactOpts.Nonce = big.NewInt(int64(nonce))
-	_, err = lendingRelayerRegistration.AddTerm(big.NewInt(30 * 86400))
-	if err != nil {
-		log.Fatal("Lending add terms", err)
-	}
-
 	fmt.Println("wait 2s to setup lending contract")
 	time.Sleep(2 * time.Second)
 

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -140,7 +140,7 @@ func (v *BlockValidator) ValidateTradingOrder(statedb *state.StateDB, tomoxState
 	return nil
 }
 
-func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, blockTime uint64) error {
+func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, header *types.Header) error {
 	posvEngine, ok := v.bc.Engine().(*posv.Posv)
 	if posvEngine == nil || !ok {
 		return ErrNotPoSV
@@ -160,7 +160,7 @@ func (v *BlockValidator) ValidateLendingOrder(statedb *state.StateDB, lendingSta
 
 		log.Debug("process lending tx", "lendingItem", lendingstate.ToJSON(l))
 		// process Matching Engine
-		newTrades, newRejectedOrders, err := lendingService.ApplyOrder(blockTime, coinbase, v.bc, statedb, lendingStateDb, tomoxStatedb, lendingstate.GetLendingOrderBookHash(l.LendingToken, l.Term), l)
+		newTrades, newRejectedOrders, err := lendingService.ApplyOrder(header, coinbase, v.bc, statedb, lendingStateDb, tomoxStatedb, lendingstate.GetLendingOrderBookHash(l.LendingToken, l.Term), l)
 		if err != nil {
 			return err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1564,7 +1564,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 					// liquidate / finalize open lendingTrades
 					if block.Number().Uint64()%bc.chainConfig.Posv.Epoch == common.LiquidateLendingTradeBlock {
 						finalizedTrades := map[common.Hash]*lendingstate.LendingTrade{}
-						finalizedTrades, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
+						finalizedTrades, _, _, _, _,  err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 						if err != nil {
 							return i, events, coalescedLogs, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
 						}
@@ -1853,7 +1853,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 				// liquidate / finalize open lendingTrades
 				if block.Number().Uint64()%bc.chainConfig.Posv.Epoch == common.LiquidateLendingTradeBlock {
 					finalizedTrades := map[common.Hash]*lendingstate.LendingTrade{}
-					finalizedTrades, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
+					finalizedTrades, _, _, _, _, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 					if err != nil {
 						return nil, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
 					}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1555,7 +1555,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 					}
 					for _, batch := range batches {
 						log.Debug("Verify matching transaction", "txHash", batch.TxHash.Hex())
-						err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author, block.Time().Uint64())
+						err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author, block.Header())
 						if err != nil {
 							bc.reportBlock(block, nil, err)
 							return i, events, coalescedLogs, err
@@ -1564,7 +1564,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 					// liquidate / finalize open lendingTrades
 					if block.Number().Uint64()%bc.chainConfig.Posv.Epoch == common.LiquidateLendingTradeBlock {
 						finalizedTrades := map[common.Hash]*lendingstate.LendingTrade{}
-						finalizedTrades, err = lendingService.ProcessLiquidationData(bc, block.Time(), statedb, tradingState, lendingState)
+						finalizedTrades, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 						if err != nil {
 							return i, events, coalescedLogs, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
 						}
@@ -1844,7 +1844,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 				}
 				for _, batch := range batches {
 					log.Debug("Lending Verify matching transaction", "txHash", batch.TxHash.Hex())
-					err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author, block.Time().Uint64())
+					err := bc.Validator().ValidateLendingOrder(statedb, lendingState, tradingState, batch, author, block.Header())
 					if err != nil {
 						bc.reportBlock(block, nil, err)
 						return nil, err
@@ -1853,7 +1853,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 				// liquidate / finalize open lendingTrades
 				if block.Number().Uint64()%bc.chainConfig.Posv.Epoch == common.LiquidateLendingTradeBlock {
 					finalizedTrades := map[common.Hash]*lendingstate.LendingTrade{}
-					finalizedTrades, err = lendingService.ProcessLiquidationData(bc, block.Time(), statedb, tradingState, lendingState)
+					finalizedTrades, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 					if err != nil {
 						return nil, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
 					}

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -501,7 +501,7 @@ func (pool *LendingPool) validateBalance(cloneStateDb *state.StateDB, cloneLendi
 			if err != nil {
 				return fmt.Errorf("validateOrder: failed to get collateralTokenDecimal. err: %v", err)
 			}
-			lendTokenTOMOPrice, collateralPrice, err = lendingServ.GetCollateralPrices(pool.chain, cloneStateDb, cloneTradingStateDb, tx.CollateralToken(), tx.LendingToken())
+			lendTokenTOMOPrice, collateralPrice, err = lendingServ.GetCollateralPrices(pool.chain.CurrentHeader(), pool.chain, cloneStateDb, cloneTradingStateDb, tx.CollateralToken(), tx.LendingToken())
 			if err != nil {
 				return err
 			}

--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -168,8 +168,8 @@ func testSendLending(key string, nonce uint64, lendToken, collateralToken common
 }
 
 func TestSendLending(t *testing.T) {
-	t.SkipNow() //TODO: remove it to run this test
-	key := ""
+	//t.SkipNow() //TODO: remove it to run this test
+	key := "65ec4d4dfbcac594a14c36baa462d6f73cd86134840f6cf7b80a1e1cd33473e2"
 	privateKey, err := crypto.HexToECDSA(key)
 	if err != nil {
 		log.Print(err)

--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -168,8 +168,8 @@ func testSendLending(key string, nonce uint64, lendToken, collateralToken common
 }
 
 func TestSendLending(t *testing.T) {
-	//t.SkipNow() //TODO: remove it to run this test
-	key := "65ec4d4dfbcac594a14c36baa462d6f73cd86134840f6cf7b80a1e1cd33473e2"
+	t.SkipNow() //TODO: remove it to run this test
+	key := ""
 	privateKey, err := crypto.HexToECDSA(key)
 	if err != nil {
 		log.Print(err)

--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -130,20 +130,20 @@ func testSendLending(key string, nonce uint64, lendToken, collateralToken common
 		log.Print(err)
 	}
 	msg := &LendingMsg{
-		AccountNonce:    nonce,
-		Quantity:        amount,
-		RelayerAddress:  common.HexToAddress("0x0D3ab14BBaD3D99F4203bd7a11aCB94882050E7e"),
-		UserAddress:     crypto.PubkeyToAddress(privateKey.PublicKey),
-		LendingToken:    lendToken,
-		Status:          status,
-		Side:            side,
-		Type:            "LO",
-		Term:            86400,
-		AutoTopUp:       autoTopUp,
-		Interest:        interest,
-		LendingId:       lendingId,
-		LendingTradeId:  tradeId,
-		ExtraData:       extraData,
+		AccountNonce:   nonce,
+		Quantity:       amount,
+		RelayerAddress: common.HexToAddress("0x0D3ab14BBaD3D99F4203bd7a11aCB94882050E7e"),
+		UserAddress:    crypto.PubkeyToAddress(privateKey.PublicKey),
+		LendingToken:   lendToken,
+		Status:         status,
+		Side:           side,
+		Type:           "LO",
+		Term:           86400,
+		AutoTopUp:      autoTopUp,
+		Interest:       interest,
+		LendingId:      lendingId,
+		LendingTradeId: tradeId,
+		ExtraData:      extraData,
 	}
 	if msg.Side == lendingstate.Borrowing {
 		msg.CollateralToken = collateralToken
@@ -256,7 +256,32 @@ func TestCancelLending(t *testing.T) {
 	interestRate := 10 * common.BaseLendingInterest.Uint64()
 	testSendLending(key, nonce, USDAddress, common.Address{}, new(big.Int).Mul(_1E8, big.NewInt(1000)), interestRate, lendingstate.Investing, lendingstate.LendingStatusNew, true, 0, 0, common.Hash{}, "")
 	nonce++
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 	//TODO: run the above testcase first, then updating lendingId, Hash
 	testSendLending(key, nonce, USDAddress, common.Address{}, new(big.Int).Mul(_1E8, big.NewInt(1000)), interestRate, lendingstate.Investing, lendingstate.LendingStatusCancelled, true, 1, 0, common.HexToHash("0x3da4e24b9c0f60e04cdb4c4494de37203c6e1a354907cbd6d9bbbe2e52aecaab"), "")
+
+}
+
+func TestRecallLending(t *testing.T) {
+	t.SkipNow() //TODO: remove it to run this test
+	key := ""
+	privateKey, err := crypto.HexToECDSA(key)
+	if err != nil {
+		log.Print(err)
+	}
+	nonce, err := getLendingNonce(crypto.PubkeyToAddress(privateKey.PublicKey))
+	if err != nil {
+		t.Error("fail to get nonce")
+		t.FailNow()
+	}
+	interestRate := 10 * common.BaseLendingInterest.Uint64()
+	testSendLending(key, nonce, USDAddress, common.Address{}, new(big.Int).Mul(_1E8, big.NewInt(1000)), interestRate, lendingstate.Investing, lendingstate.LendingStatusNew, true, 0, 0, common.Hash{}, "")
+	time.Sleep(2 * time.Second)
+	nonce, err = getLendingNonce(crypto.PubkeyToAddress(privateKey.PublicKey))
+	if err != nil {
+		t.Error("fail to get nonce")
+		t.FailNow()
+	}
+	testSendLending(key, nonce, USDAddress, common.HexToAddress(common.TomoNativeAddress), new(big.Int).Mul(_1E8, big.NewInt(1000)), interestRate, lendingstate.Borrowing, lendingstate.LendingStatusNew, true, 0, 0, common.Hash{}, "")
+	time.Sleep(2 * time.Second)
 }

--- a/core/order_pool_test.go
+++ b/core/order_pool_test.go
@@ -49,7 +49,9 @@ var (
 	EOSAddress = common.HexToAddress("0xd9bb01454c85247B2ef35BB5BE57384cC275a8cf")
 	USDAddress = common.HexToAddress("0x45c25041b8e6CBD5c963E7943007187C3673C7c9")
 	_1E18      = new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(100))
+	_1E17      = new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(10))
 	_1E8       = big.NewInt(100000000)
+	_1E7       = big.NewInt(10000000)
 )
 
 func getNonce(t *testing.T, userAddress common.Address) (uint64, error) {
@@ -265,7 +267,7 @@ func TestFilled(t *testing.T) {
 	//testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(5000)), BTCUSDPrice, "BUY", "NEW", 0)
 	//ETH/BTC
 
-	BTCUSDPrice := new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(1000000)) // 10000
+	BTCUSDPrice := new(big.Int).Mul(_1E8, big.NewInt(10000)) // 10000
 	time.Sleep(2 * time.Second)
 	testSendOrderBTCUSD(t, _1E18, BTCUSDPrice, "BUY", "NEW", 0)
 	time.Sleep(2 * time.Second)
@@ -281,7 +283,18 @@ func TestFilled(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	testSendOrderTOMOBTC(t, new(big.Int).Mul(big.NewInt(1200000), _1E18), TOMOBTCPrice, "SELL", "NEW", 0)
 
-	TOMOUSDPrice := new(big.Int).Mul(big.NewInt(10000000000000), big.NewInt(60000)) // 0.6
+	TOMOUSDPrice := new(big.Int).Mul(_1E7, big.NewInt(6)) // 0.6
+	time.Sleep(2 * time.Second)
+	testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(600000), _1E18), TOMOUSDPrice, "BUY", "NEW", 0)
+	time.Sleep(2 * time.Second)
+	testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(600000), _1E18), TOMOUSDPrice, "BUY", "NEW", 0)
+	time.Sleep(2 * time.Second)
+	testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(1200000), _1E18), TOMOUSDPrice, "SELL", "NEW", 0)
+
+}
+
+func TestX10Filled(t *testing.T) {
+	TOMOUSDPrice := new(big.Int).Mul(_1E7, big.NewInt(60)) // 6
 	time.Sleep(2 * time.Second)
 	testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(600000), _1E18), TOMOUSDPrice, "BUY", "NEW", 0)
 	time.Sleep(2 * time.Second)

--- a/core/order_pool_test.go
+++ b/core/order_pool_test.go
@@ -49,7 +49,9 @@ var (
 	EOSAddress = common.HexToAddress("0xd9bb01454c85247B2ef35BB5BE57384cC275a8cf")
 	USDAddress = common.HexToAddress("0x45c25041b8e6CBD5c963E7943007187C3673C7c9")
 	_1E18      = new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(100))
+	_1E17      = new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(10))
 	_1E8       = big.NewInt(100000000)
+	_1E7       = big.NewInt(10000000)
 )
 
 func getNonce(t *testing.T, userAddress common.Address) (uint64, error) {
@@ -265,7 +267,7 @@ func TestFilled(t *testing.T) {
 	//testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(5000)), BTCUSDPrice, "BUY", "NEW", 0)
 	//ETH/BTC
 
-	BTCUSDPrice := new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(1000000)) // 10000
+	BTCUSDPrice := new(big.Int).Mul(_1E8, big.NewInt(10000)) // 10000
 	time.Sleep(2 * time.Second)
 	testSendOrderBTCUSD(t, _1E18, BTCUSDPrice, "BUY", "NEW", 0)
 	time.Sleep(2 * time.Second)
@@ -281,7 +283,7 @@ func TestFilled(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	testSendOrderTOMOBTC(t, new(big.Int).Mul(big.NewInt(1200000), _1E18), TOMOBTCPrice, "SELL", "NEW", 0)
 
-	TOMOUSDPrice := new(big.Int).Mul(big.NewInt(10000000000000), big.NewInt(60000)) // 0.6
+	TOMOUSDPrice := new(big.Int).Mul(_1E7, big.NewInt(6)) // 0.6
 	time.Sleep(2 * time.Second)
 	testSendOrderTOMOUSD(t, new(big.Int).Mul(big.NewInt(600000), _1E18), TOMOUSDPrice, "BUY", "NEW", 0)
 	time.Sleep(2 * time.Second)

--- a/core/types.go
+++ b/core/types.go
@@ -40,7 +40,7 @@ type Validator interface {
 
 	ValidateTradingOrder(statedb *state.StateDB, tomoxStatedb *tradingstate.TradingStateDB, txMatchBatch tradingstate.TxMatchBatch, coinbase common.Address) error
 
-	ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, blockTime uint64) error
+	ValidateLendingOrder(statedb *state.StateDB, lendingStateDb *lendingstate.LendingStateDB, tomoxStatedb *tradingstate.TradingStateDB, batch lendingstate.TxLendingBatch, coinbase common.Address, headr *types.Header) error
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -623,16 +623,17 @@ func (self *worker) commitNewWork() {
 	}
 	// won't grasp txs at checkpoint
 	var (
-		txs                              *types.TransactionsByPriceAndNonce
-		specialTxs                       types.Transactions
-		tradingTransaction               *types.Transaction
-		lendingTransaction               *types.Transaction
-		tradingTxMatches                 []tradingstate.TxDataMatch
-		tradingMatchingResults           map[common.Hash]tradingstate.MatchingResult
-		lendingMatchingResults           map[common.Hash]lendingstate.MatchingResult
-		lendingInput                     []*lendingstate.LendingItem
-		finalizedTrades                  map[common.Hash]*lendingstate.LendingTrade
-		lendingFinalizedTradeTransaction *types.Transaction
+		txs                                                                  *types.TransactionsByPriceAndNonce
+		specialTxs                                                           types.Transactions
+		tradingTransaction                                                   *types.Transaction
+		lendingTransaction                                                   *types.Transaction
+		tradingTxMatches                                                     []tradingstate.TxDataMatch
+		tradingMatchingResults                                               map[common.Hash]tradingstate.MatchingResult
+		lendingMatchingResults                                               map[common.Hash]lendingstate.MatchingResult
+		lendingInput                                                         []*lendingstate.LendingItem
+		updatedTrades                                                        map[common.Hash]*lendingstate.LendingTrade
+		liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*lendingstate.LendingTrade
+		lendingFinalizedTradeTransaction                                     *types.Transaction
 	)
 	feeCapacity := state.GetTRC21FeeCapacityFromStateWithCache(parent.Root(), work.state)
 	if self.config.Posv != nil && header.Number.Uint64()%self.config.Posv.Epoch != 0 {
@@ -673,7 +674,7 @@ func (self *worker) commitNewWork() {
 					lendingInput, lendingMatchingResults = tomoXLending.ProcessOrderPending(header, self.coinbase, self.chain, lendingOrderPending, work.state, work.lendingState, work.tradingState)
 					log.Debug("lending transaction matches found", "lendingInput", len(lendingInput), "lendingMatchingResults", len(lendingMatchingResults))
 					if header.Number.Uint64()%self.config.Posv.Epoch == common.LiquidateLendingTradeBlock {
-						finalizedTrades, err = tomoXLending.ProcessLiquidationData(header, self.chain, work.state, work.tradingState, work.lendingState)
+						updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err = tomoXLending.ProcessLiquidationData(header, self.chain, work.state, work.tradingState, work.lendingState)
 						if err != nil {
 							log.Error("Fail when process lending liquidation data ", "error", err)
 							return
@@ -730,9 +731,9 @@ func (self *worker) commitNewWork() {
 					}
 				}
 
-				if len(finalizedTrades) > 0 {
+				if len(updatedTrades) > 0 {
 					log.Debug("M1 finalized trades")
-					finalizedTradeData, err := lendingstate.EncodeFinalizedResult(finalizedTrades)
+					finalizedTradeData, err := lendingstate.EncodeFinalizedResult(liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades)
 					if err != nil {
 						log.Error("Fail to marshal lendingData", "error", err)
 						return
@@ -746,7 +747,7 @@ func (self *worker) commitNewWork() {
 					} else {
 						lendingFinalizedTradeTransaction = signedFinalizedTx
 						if tomoX.IsSDKNode() {
-							self.chain.AddFinalizedTrades(lendingFinalizedTradeTransaction.Hash(), finalizedTrades)
+							self.chain.AddFinalizedTrades(lendingFinalizedTradeTransaction.Hash(), updatedTrades)
 						}
 					}
 				}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -670,10 +670,10 @@ func (self *worker) commitNewWork() {
 					log.Debug("trading transaction matches found", "tradingTxMatches", len(tradingTxMatches))
 
 					lendingOrderPending, _ := self.eth.LendingPool().Pending()
-					lendingInput, lendingMatchingResults = tomoXLending.ProcessOrderPending(header.Time.Uint64(), self.coinbase, self.chain, lendingOrderPending, work.state, work.lendingState, work.tradingState)
+					lendingInput, lendingMatchingResults = tomoXLending.ProcessOrderPending(header, self.coinbase, self.chain, lendingOrderPending, work.state, work.lendingState, work.tradingState)
 					log.Debug("lending transaction matches found", "lendingInput", len(lendingInput), "lendingMatchingResults", len(lendingMatchingResults))
-					if header.Number.Uint64() % self.config.Posv.Epoch == common.LiquidateLendingTradeBlock {
-						finalizedTrades, err = tomoXLending.ProcessLiquidationData(self.chain, header.Time, work.state, work.tradingState, work.lendingState)
+					if header.Number.Uint64()%self.config.Posv.Epoch == common.LiquidateLendingTradeBlock {
+						finalizedTrades, err = tomoXLending.ProcessLiquidationData(header, self.chain, work.state, work.tradingState, work.lendingState)
 						if err != nil {
 							log.Error("Fail when process lending liquidation data ", "error", err)
 							return

--- a/tomox/tradingstate/database.go
+++ b/tomox/tradingstate/database.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"sync"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/ethdb"
 	"github.com/tomochain/tomochain/trie"
-	lru "github.com/hashicorp/golang-lru"
 )
 
 // Trie cache generation limit after which to evic trie nodes from memory.
@@ -63,6 +63,7 @@ type Database interface {
 type Trie interface {
 	TryGet(key []byte) ([]byte, error)
 	TryGetBestLeftKeyAndValue() ([]byte, []byte, error)
+	TryGetAllLeftKeyAndValue(limit []byte) ([][]byte, [][]byte, error)
 	TryGetBestRightKeyAndValue() ([]byte, []byte, error)
 	TryUpdate(key, value []byte) error
 	TryDelete(key []byte) error

--- a/tomox/tradingstate/statedb.go
+++ b/tomox/tradingstate/statedb.go
@@ -613,7 +613,7 @@ func (self *TradingStateDB) GetLowestLiquidationPriceData(orderBook common.Hash,
 	}
 	lowestPriceHash, liquidationState := orderbookState.getLowestLiquidationPrice(self.db)
 	lowestPrice := new(big.Int).SetBytes(lowestPriceHash[:])
-	if liquidationState != nil && lowestPrice.Sign() > 0 && lowestPrice.Cmp(price) <= 0 {
+	if liquidationState != nil && lowestPrice.Sign() > 0 && lowestPrice.Cmp(price) < 0 {
 		priceLiquidationData := liquidationState.getAllLiquidationData(self.db)
 		for lendingBook, data := range priceLiquidationData {
 			if len(data) == 0 {

--- a/tomox/tradingstate/statedb.go
+++ b/tomox/tradingstate/statedb.go
@@ -605,30 +605,35 @@ func (s *TradingStateDB) Commit() (root common.Hash, err error) {
 	return root, err
 }
 
-func (self *TradingStateDB) GetLowestLiquidationPriceData(orderBook common.Hash, price *big.Int) (*big.Int, map[common.Hash][]common.Hash) {
-	liquidationData := map[common.Hash][]common.Hash{}
+func (self *TradingStateDB) GetAllLowerLiquidationPriceData(orderBook common.Hash, limit *big.Int) map[*big.Int]map[common.Hash][]common.Hash {
+	result := map[*big.Int]map[common.Hash][]common.Hash{}
 	orderbookState := self.getStateExchangeObject(orderBook)
 	if orderbookState == nil {
-		return common.Big0, liquidationData
+		return result
 	}
-	lowestPriceHash, liquidationState := orderbookState.getLowestLiquidationPrice(self.db)
-	lowestPrice := new(big.Int).SetBytes(lowestPriceHash[:])
-	if liquidationState != nil && lowestPrice.Sign() > 0 && lowestPrice.Cmp(price) <= 0 {
-		priceLiquidationData := liquidationState.getAllLiquidationData(self.db)
-		for lendingBook, data := range priceLiquidationData {
-			if len(data) == 0 {
-				continue
+	mapPrices := orderbookState.getAllLowerLiquidationPrice(self.db, common.BigToHash(limit))
+	for priceHash, liquidationState := range mapPrices {
+		price := new(big.Int).SetBytes(priceHash[:])
+		log.Debug("GetAllLowerLiquidationPriceData", "price", price, "limit", limit)
+		if liquidationState != nil && price.Sign() > 0 && price.Cmp(limit) < 0 {
+			liquidationData := map[common.Hash][]common.Hash{}
+			priceLiquidationData := liquidationState.getAllLiquidationData(self.db)
+			for lendingBook, data := range priceLiquidationData {
+				if len(data) == 0 {
+					continue
+				}
+				oldData := liquidationData[lendingBook]
+				if len(oldData) == 0 {
+					oldData = data
+				} else {
+					oldData = append(oldData, data...)
+				}
+				liquidationData[lendingBook] = oldData
 			}
-			oldData := liquidationData[lendingBook]
-			if len(oldData) == 0 {
-				oldData = data
-			} else {
-				oldData = append(oldData, data...)
-			}
-			liquidationData[lendingBook] = oldData
+			result[price] = liquidationData
 		}
 	}
-	return lowestPrice, liquidationData
+	return result
 }
 
 func (self *TradingStateDB) GetHighestLiquidationPriceData(orderBook common.Hash, price *big.Int) (*big.Int, map[common.Hash][]common.Hash) {

--- a/tomox/tradingstate/statedb_test.go
+++ b/tomox/tradingstate/statedb_test.go
@@ -67,8 +67,8 @@ func TestEchangeStates(t *testing.T) {
 	}
 	statedb.SetLastPrice(orderBook, price)
 	statedb.InsertLiquidationPrice(orderBook, big.NewInt(1), orderBook, 2)
-	statedb.InsertLiquidationPrice(orderBook, big.NewInt(1), orderBook, 3)
-	statedb.InsertLiquidationPrice(orderBook, big.NewInt(2), orderBook, 1)
+	statedb.InsertLiquidationPrice(orderBook, big.NewInt(2), orderBook, 3)
+	statedb.InsertLiquidationPrice(orderBook, big.NewInt(3), orderBook, 1)
 	root := statedb.IntermediateRoot()
 	statedb.Commit()
 	//err := stateCache.TrieDB().Commit(root, false)
@@ -80,7 +80,7 @@ func TestEchangeStates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when get trie in database: %s , err: %v", root.Hex(), err)
 	}
-	liquidationPrice, liquidationData := statedb.GetLowestLiquidationPriceData(orderBook, big.NewInt(1))
+	liquidationPrice, liquidationData := statedb.GetHighestLiquidationPriceData(orderBook, big.NewInt(1))
 	if len(liquidationData) == 0 {
 		t.Fatalf("Error when get liquidation data save in database: got : %d , %s  ", liquidationPrice, liquidationData)
 	}
@@ -94,7 +94,7 @@ func TestEchangeStates(t *testing.T) {
 			}
 		}
 	}
-	liquidationPrice, liquidationData = statedb.GetLowestLiquidationPriceData(orderBook, big.NewInt(1))
+	liquidationPrice, liquidationData = statedb.GetHighestLiquidationPriceData(orderBook, big.NewInt(2))
 	for lendingBook, tradingIds := range liquidationData {
 		for _, tradingIdHash := range tradingIds {
 			fmt.Println("liquidationPrice", liquidationPrice, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex())

--- a/tomox/tradingstate/tomox_trie.go
+++ b/tomox/tradingstate/tomox_trie.go
@@ -88,6 +88,10 @@ func (t *TomoXTrie) TryGetBestLeftKeyAndValue() ([]byte, []byte, error) {
 	return t.trie.TryGetBestLeftKeyAndValue()
 }
 
+func (t *TomoXTrie) TryGetAllLeftKeyAndValue(limit []byte ) ([][]byte, [][]byte, error) {
+	return t.trie.TryGetAllLeftKeyAndValue(limit)
+}
+
 // TryGetBestRightKey returns the value of max left leaf
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *TomoXTrie) TryGetBestRightKeyAndValue() ([]byte, []byte, error) {

--- a/tomox/tradingstate/tomox_trie_test.go
+++ b/tomox/tradingstate/tomox_trie_test.go
@@ -5,22 +5,42 @@ import (
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/ethdb"
 	"math/big"
+	"math/rand"
 	"testing"
+	"time"
 )
 
 func TestTomoxTrieTest(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
 	stateCache := NewDatabase(db)
 	trie, _ := stateCache.OpenStorageTrie(EmptyHash, EmptyHash)
-	min := common.BigToHash(big.NewInt(1)).Bytes()
-	max := common.BigToHash(big.NewInt(2)).Bytes()
-	trie.TryUpdate(min, min)
-	trie.TryUpdate(max, max)
+	max := 1000000
+	for i := 1; i < max; i++ {
+		k := common.BigToHash(big.NewInt(int64(i))).Bytes()
+		trie.TryUpdate(k, k)
+	}
 	left, _, _ := trie.TryGetBestLeftKeyAndValue()
 	right, _, _ := trie.TryGetBestRightKeyAndValue()
 	fmt.Println(left, right)
-	trie.TryDelete(min)
-	left, _, _ = trie.TryGetBestLeftKeyAndValue()
-	right, _, _ = trie.TryGetBestRightKeyAndValue()
-	fmt.Println(left, right)
+	for i := 0; i < 100; i++ {
+		limit := big.NewInt(rand.Int63n(int64(max / 10)))
+		fmt.Println(time.Now().Format("2006-01-02 15:04:05"), "test", i, limit)
+		allKeyLefts, allValues, err := trie.TryGetAllLeftKeyAndValue(common.BigToHash(limit).Bytes())
+		if err != nil {
+			t.Fatal("err", err)
+		}
+		if len(allKeyLefts) != int(limit.Int64())-1 {
+			t.Fatal("err when length", len(allKeyLefts), "limit", limit)
+		}
+		for j := 0; j < len(allKeyLefts); j++ {
+			key := new(big.Int).SetBytes(allKeyLefts[j])
+			value := new(big.Int).SetBytes(allValues[j])
+			if key.Cmp(value) != 0 {
+				t.Fatal("err when compare key", key, "value", value)
+			}
+			if key.Cmp(limit) >= 0 {
+				t.Fatal("err when compare key", key, "limit", limit)
+			}
+		}
+	}
 }

--- a/tomoxDAO/mongodb.go
+++ b/tomoxDAO/mongodb.go
@@ -125,7 +125,17 @@ func (db *MongoDatabase) HasObject(hash common.Hash, val interface{}) (bool, err
 		}
 	case *lendingstate.LendingItem:
 		// Find key in lendingItemsCollection collection
-		count, err = sc.DB(db.dbName).C(lendingItemsCollection).Find(query).Limit(1).Count()
+		item := val.(*lendingstate.LendingItem)
+		switch item.Type {
+		case lendingstate.Repay:
+			count, err = sc.DB(db.dbName).C(lendingRepayCollection).Find(query).Limit(1).Count()
+		case lendingstate.TopUp:
+			count, err = sc.DB(db.dbName).C(lendingTopUpCollection).Find(query).Limit(1).Count()
+		case lendingstate.Recall:
+			count, err = sc.DB(db.dbName).C(lendingRecallCollection).Find(query).Limit(1).Count()
+		default:
+			count, err = sc.DB(db.dbName).C(lendingItemsCollection).Find(query).Limit(1).Count()
+		}
 
 		if err != nil {
 			return false, err
@@ -186,14 +196,16 @@ func (db *MongoDatabase) GetObject(hash common.Hash, val interface{}) (interface
 			var li *lendingstate.LendingItem
 			var err error
 			item := val.(*lendingstate.LendingItem)
-			if item.Type == lendingstate.Repay {
+			switch item.Type {
+			case lendingstate.Repay:
 				err = sc.DB(db.dbName).C(lendingRepayCollection).Find(query).One(&li)
-			} else if item.Type == lendingstate.TopUp {
+			case lendingstate.TopUp:
 				err = sc.DB(db.dbName).C(lendingTopUpCollection).Find(query).One(&li)
-			} else {
+			case lendingstate.Recall:
+				err = sc.DB(db.dbName).C(lendingRecallCollection).Find(query).One(&li)
+			default:
 				err = sc.DB(db.dbName).C(lendingItemsCollection).Find(query).One(&li)
 			}
-
 			if err != nil {
 				return nil, err
 			}
@@ -248,35 +260,35 @@ func (db *MongoDatabase) PutObject(hash common.Hash, val interface{}) error {
 	case *lendingstate.LendingItem:
 		// PutObject order into ordersCollection collection
 		li := val.(*lendingstate.LendingItem)
-		if li.Type == lendingstate.Repay {
+		switch li.Type {
+		case lendingstate.Repay:
 			if li.Status != lendingstate.LendingStatusReject {
 				li.Status = lendingstate.Repay
 			}
 			db.repayBulk.Insert(li)
 			return nil
-		}
-		if li.Type == lendingstate.Recall {
-			if li.Status != lendingstate.LendingStatusReject {
-				li.Status = lendingstate.Recall
-			}
-			li.FilledAmount = li.Quantity
-			db.recallBulk.Insert(li)
-			return nil
-		}
-		if li.Type == lendingstate.TopUp {
+		case lendingstate.TopUp:
 			if li.Status != lendingstate.LendingStatusReject {
 				li.Status = lendingstate.TopUp
 			}
 			db.topUpBulk.Insert(li)
 			return nil
+		case lendingstate.Recall:
+			if li.Status != lendingstate.LendingStatusReject {
+				li.Status = lendingstate.Recall
+			}
+			db.recallBulk.Insert(li)
+			return nil
+		default:
+			if li.Status == lendingstate.LendingStatusOpen {
+				db.lendingItemBulk.Insert(li)
+			} else {
+				query := bson.M{"hash": li.Hash.Hex()}
+				db.lendingItemBulk.Upsert(query, li)
+			}
+			return nil
 		}
-		if li.Status == lendingstate.LendingStatusOpen {
-			db.lendingItemBulk.Insert(li)
-		} else {
-			query := bson.M{"hash": li.Hash.Hex()}
-			db.lendingItemBulk.Upsert(query, li)
-		}
-		return nil
+
 	default:
 		log.Error("PutObject: unknown type of object", "val", val)
 	}
@@ -313,11 +325,14 @@ func (db *MongoDatabase) DeleteObject(hash common.Hash, val interface{}) error {
 			}
 		case *lendingstate.LendingItem:
 			item := val.(*lendingstate.LendingItem)
-			if item.Type == lendingstate.Repay {
+			switch item.Type {
+			case lendingstate.Repay:
 				err = sc.DB(db.dbName).C(lendingRepayCollection).Remove(query)
-			} else if item.Type == lendingstate.TopUp {
+			case lendingstate.TopUp:
 				err = sc.DB(db.dbName).C(lendingTopUpCollection).Remove(query)
-			} else {
+			case lendingstate.Recall:
+				err = sc.DB(db.dbName).C(lendingRecallCollection).Remove(query)
+			default:
 				err = sc.DB(db.dbName).C(lendingItemsCollection).Remove(query)
 			}
 			if err != nil && err != mgo.ErrNotFound {
@@ -419,21 +434,29 @@ func (db *MongoDatabase) DeleteItemByTxHash(txhash common.Hash, val interface{})
 		}
 	case *lendingstate.LendingItem:
 		item := val.(*lendingstate.LendingItem)
-		if item.Type == lendingstate.Repay {
+		switch item.Type {
+		case lendingstate.Repay:
 			if err := sc.DB(db.dbName).C(lendingRepayCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
 				log.Error("DeleteItemByTxHash: failed to delete repayItem", "txhash", txhash, "err", err)
 			}
 			return
-		}
-		if item.Type == lendingstate.TopUp {
+		case lendingstate.TopUp:
 			if err := sc.DB(db.dbName).C(lendingTopUpCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
 				log.Error("DeleteItemByTxHash: failed to delete topupItem", "txhash", txhash, "err", err)
 			}
 			return
+		case lendingstate.Recall:
+			if err := sc.DB(db.dbName).C(lendingRecallCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
+				log.Error("DeleteItemByTxHash: failed to delete recallItem", "txhash", txhash, "err", err)
+			}
+			return
+		default:
+			if err := sc.DB(db.dbName).C(lendingItemsCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
+				log.Error("DeleteItemByTxHash: failed to delete lendingItem", "txhash", txhash, "err", err)
+			}
+			return
 		}
-		if err := sc.DB(db.dbName).C(lendingItemsCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
-			log.Error("DeleteItemByTxHash: failed to delete lendingItem", "txhash", txhash, "err", err)
-		}
+
 	case *lendingstate.LendingTrade:
 		if err := sc.DB(db.dbName).C(lendingTradesCollection).Remove(query); err != nil && err != mgo.ErrNotFound {
 			log.Error("DeleteItemByTxHash: failed to delete lendingTrade", "txhash", txhash, "err", err)
@@ -465,22 +488,28 @@ func (db *MongoDatabase) GetListItemByTxHash(txhash common.Hash, val interface{}
 	case *lendingstate.LendingItem:
 		item := val.(*lendingstate.LendingItem)
 		result := []*lendingstate.LendingItem{}
-		if item.Type == lendingstate.Repay {
+		switch item.Type {
+		case lendingstate.Repay:
 			if err := sc.DB(db.dbName).C(lendingRepayCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
-				log.Error("failed to GetListItemByTxHash (lendingItems)", "err", err, "Txhash", txhash)
+				log.Error("failed to GetListItemByTxHash (repayItems)", "err", err, "txhash", txhash)
 			}
 			return result
-		}
-		if item.Type == lendingstate.TopUp {
+		case lendingstate.TopUp:
 			if err := sc.DB(db.dbName).C(lendingTopUpCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
-				log.Error("failed to GetListItemByTxHash (lendingItems)", "err", err, "Txhash", txhash)
+				log.Error("failed to GetListItemByTxHash (topupItems)", "err", err, "txhash", txhash)
+			}
+			return result
+		case lendingstate.Recall:
+			if err := sc.DB(db.dbName).C(lendingRecallCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
+				log.Error("failed to GetListItemByTxHash (recallItems)", "err", err, "txhash", txhash)
+			}
+			return result
+		default:
+			if err := sc.DB(db.dbName).C(lendingItemsCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
+				log.Error("failed to GetListItemByTxHash (lendingItems)", "err", err, "txhash", txhash)
 			}
 			return result
 		}
-		if err := sc.DB(db.dbName).C(lendingItemsCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
-			log.Error("failed to GetListItemByTxHash (lendingItems)", "err", err, "Txhash", txhash)
-		}
-		return result
 	case *lendingstate.LendingTrade:
 		result := []*lendingstate.LendingTrade{}
 		if err := sc.DB(db.dbName).C(lendingTradesCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
@@ -515,22 +544,28 @@ func (db *MongoDatabase) GetListItemByHashes(hashes []string, val interface{}) i
 	case *lendingstate.LendingItem:
 		item := val.(*lendingstate.LendingItem)
 		result := []*lendingstate.LendingItem{}
-		if item.Type == lendingstate.Repay {
+		switch item.Type {
+		case lendingstate.Repay:
 			if err := sc.DB(db.dbName).C(lendingRepayCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
-				log.Error("failed to GetListItemByHashes (lendingItems)", "err", err, "hashes", hashes)
+				log.Error("failed to GetListItemByHashes (repayItems)", "err", err, "hashes", hashes)
 			}
 			return result
-		}
-		if item.Type == lendingstate.TopUp {
+		case lendingstate.TopUp:
 			if err := sc.DB(db.dbName).C(lendingTopUpCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
+				log.Error("failed to GetListItemByHashes (topupItems)", "err", err, "hashes", hashes)
+			}
+			return result
+		case lendingstate.Recall:
+			if err := sc.DB(db.dbName).C(lendingRecallCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
+				log.Error("failed to GetListItemByHashes (recallItems)", "err", err, "hashes", hashes)
+			}
+			return result
+		default:
+			if err := sc.DB(db.dbName).C(lendingItemsCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
 				log.Error("failed to GetListItemByHashes (lendingItems)", "err", err, "hashes", hashes)
 			}
 			return result
 		}
-		if err := sc.DB(db.dbName).C(lendingItemsCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
-			log.Error("failed to GetListItemByHashes (lendingItems)", "err", err, "hashes", hashes)
-		}
-		return result
 	case *lendingstate.LendingTrade:
 		result := []*lendingstate.LendingTrade{}
 		if err := sc.DB(db.dbName).C(lendingTradesCollection).Find(query).All(&result); err != nil && err != mgo.ErrNotFound {

--- a/tomoxlending/lendingstate/lendingcontract.go
+++ b/tomoxlending/lendingstate/lendingcontract.go
@@ -25,7 +25,9 @@ var (
 	CollateralStructSlots = map[string]*big.Int{
 		"depositRate":     big.NewInt(0),
 		"liquidationRate": big.NewInt(1),
-		"price":           big.NewInt(2),
+		"recallRate":      big.NewInt(2),
+		"price":           big.NewInt(3),
+		"blockNumber":     big.NewInt(4),
 	}
 )
 
@@ -169,15 +171,19 @@ func GetCollaterals(statedb *state.StateDB, coinbase common.Address, baseToken c
 // @param statedb : current state
 // @param token: address of collateral token
 // @return: depositRate, liquidationRate, price of collateral
-func GetCollateralDetail(statedb *state.StateDB, token common.Address) (depositRate *big.Int, liquidationRate *big.Int, price *big.Int) {
+func GetCollateralDetail(statedb *state.StateDB, token common.Address) (depositRate, liquidationRate, price, recallRate, blockNumber *big.Int) {
 	collateralState := GetLocMappingAtKey(token.Hash(), CollateralMapSlot)
 	locDepositRate := state.GetLocOfStructElement(collateralState, CollateralStructSlots["depositRate"])
 	locLiquidationRate := state.GetLocOfStructElement(collateralState, CollateralStructSlots["liquidationRate"])
 	locCollateralPrice := state.GetLocOfStructElement(collateralState, CollateralStructSlots["price"])
+	locRecallRate := state.GetLocOfStructElement(collateralState, CollateralStructSlots["recallRate"])
+	locBlockNumber := state.GetLocOfStructElement(collateralState, CollateralStructSlots["blockNumber"])
 	depositRate = statedb.GetState(common.HexToAddress(common.LendingRegistrationSMC), locDepositRate).Big()
 	liquidationRate = statedb.GetState(common.HexToAddress(common.LendingRegistrationSMC), locLiquidationRate).Big()
 	price = statedb.GetState(common.HexToAddress(common.LendingRegistrationSMC), locCollateralPrice).Big()
-	return depositRate, liquidationRate, price
+	recallRate = statedb.GetState(common.HexToAddress(common.LendingRegistrationSMC), locRecallRate).Big()
+	blockNumber = statedb.GetState(common.HexToAddress(common.LendingRegistrationSMC), locBlockNumber).Big()
+	return depositRate, liquidationRate, price, recallRate, blockNumber
 }
 
 // @function GetSupportedTerms

--- a/tomoxlending/lendingstate/lendingitem.go
+++ b/tomoxlending/lendingstate/lendingitem.go
@@ -17,6 +17,7 @@ const (
 	Borrowing                  = "BORROW"
 	TopUp                      = "TOPUP"
 	Repay                      = "REPAY"
+	Recall                     = "RECALL"
 	LendingStatusNew           = "NEW"
 	LendingStatusOpen          = "OPEN"
 	LendingStatusReject        = "REJECTED"
@@ -37,6 +38,7 @@ var ValidInputLendingType = map[string]bool{
 	Limit:  true,
 	Repay:  true,
 	TopUp:  true,
+	Recall: true,
 }
 
 // Signature struct
@@ -384,7 +386,7 @@ func VerifyBalance(statedb *state.StateDB, lendingStateDb *LendingStateDB,
 		case Borrowing:
 			switch status {
 			case LendingStatusNew:
-				depositRate, _, _,_,_ := GetCollateralDetail(statedb, collateralToken)
+				depositRate, _, _, _, _ := GetCollateralDetail(statedb, collateralToken)
 				settleBalanceResult, err := GetSettleBalance(Borrowing, lendTokenTOMOPrice, collateralPrice, depositRate, borrowingFeeRate, lendingToken, collateralToken, lendingTokenDecimal, collateralTokenDecimal, quantity)
 				if err != nil {
 					return err

--- a/tomoxlending/lendingstate/lendingitem.go
+++ b/tomoxlending/lendingstate/lendingitem.go
@@ -384,7 +384,7 @@ func VerifyBalance(statedb *state.StateDB, lendingStateDb *LendingStateDB,
 		case Borrowing:
 			switch status {
 			case LendingStatusNew:
-				depositRate, _, _ := GetCollateralDetail(statedb, collateralToken)
+				depositRate, _, _,_,_ := GetCollateralDetail(statedb, collateralToken)
 				settleBalanceResult, err := GetSettleBalance(Borrowing, lendTokenTOMOPrice, collateralPrice, depositRate, borrowingFeeRate, lendingToken, collateralToken, lendingTokenDecimal, collateralTokenDecimal, quantity)
 				if err != nil {
 					return err

--- a/tomoxlending/order_processor.go
+++ b/tomoxlending/order_processor.go
@@ -5,17 +5,18 @@ import (
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
 	"github.com/tomochain/tomochain/core/state"
+	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"github.com/tomochain/tomochain/tomoxlending/lendingstate"
 	"math/big"
 )
 
-func (l *Lending) CommitOrder(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+func (l *Lending) CommitOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
 	lendingSnap := lendingStateDB.Snapshot()
 	tradingSnap := tradingStateDb.Snapshot()
 	dbSnap := statedb.Snapshot()
-	trades, rejects, err := l.ApplyOrder(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+	trades, rejects, err := l.ApplyOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
 	if err != nil {
 		lendingStateDB.RevertToSnapshot(lendingSnap)
 		tradingStateDb.RevertToSnapshot(tradingSnap)
@@ -25,7 +26,7 @@ func (l *Lending) CommitOrder(createdBlockTime uint64, coinbase common.Address, 
 	return trades, rejects, err
 }
 
-func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+func (l *Lending) ApplyOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
 	var (
 		rejects []*lendingstate.LendingItem
 		trades  []*lendingstate.LendingTrade
@@ -70,7 +71,7 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 		return trades, rejects, nil
 	case lendingstate.Repay:
 		lendingTradeId := order.LendingTradeId
-		lendingTrade, err := l.ProcessRepay(createdBlockTime, lendingStateDB, statedb, tradingStateDb, lendingOrderBook, lendingTradeId)
+		lendingTrade, err := l.ProcessRepay(header.Time.Uint64(), lendingStateDB, statedb, tradingStateDb, lendingOrderBook, lendingTradeId)
 		if err != nil {
 			log.Debug("Can not process payment", "err", err)
 			rejects = append(rejects, order)
@@ -81,7 +82,7 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 	}
 
 	if order.Status == lendingstate.LendingStatusCancelled {
-		err, reject := l.ProcessCancelOrder(lendingStateDB, statedb, tradingStateDb, chain, coinbase, lendingOrderBook, order)
+		err, reject := l.ProcessCancelOrder(header, lendingStateDB, statedb, tradingStateDb, chain, coinbase, lendingOrderBook, order)
 		if err != nil || reject {
 			rejects = append(rejects, order)
 		}
@@ -104,14 +105,14 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 	// if we do not use auto-increment orderid, we must set Interest slot to avoid conflict
 	if orderType == lendingstate.Market {
 		log.Debug("Process maket order", "side", order.Side, "quantity", order.Quantity, "Interest", order.Interest)
-		trades, rejects, err = l.processMarketOrder(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+		trades, rejects, err = l.processMarketOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
 		if err != nil {
 			trades = []*lendingstate.LendingTrade{}
 			rejects = append(rejects, order)
 		}
 	} else {
 		log.Debug("Process limit order", "side", order.Side, "quantity", order.Quantity, "Interest", order.Interest)
-		trades, rejects, err = l.processLimitOrder(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+		trades, rejects, err = l.processLimitOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
 		if err != nil {
 			trades = []*lendingstate.LendingTrade{}
 			rejects = append(rejects, order)
@@ -121,7 +122,7 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 }
 
 // processMarketOrder : process the market order
-func (l *Lending) processMarketOrder(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+func (l *Lending) processMarketOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
 	var (
 		trades     []*lendingstate.LendingTrade
 		newTrades  []*lendingstate.LendingTrade
@@ -137,7 +138,7 @@ func (l *Lending) processMarketOrder(createdBlockTime uint64, coinbase common.Ad
 		bestInterest, volume := lendingStateDB.GetBestInvestingRate(lendingOrderBook)
 		log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
 		for quantityToTrade.Cmp(zero) > 0 && bestInterest.Cmp(zero) > 0 {
-			quantityToTrade, newTrades, newRejects, err = l.processOrderList(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, bestInterest, quantityToTrade, order)
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, bestInterest, quantityToTrade, order)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -150,7 +151,7 @@ func (l *Lending) processMarketOrder(createdBlockTime uint64, coinbase common.Ad
 		bestInterest, volume := lendingStateDB.GetBestBorrowRate(lendingOrderBook)
 		log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
 		for quantityToTrade.Cmp(zero) > 0 && bestInterest.Cmp(zero) > 0 {
-			quantityToTrade, newTrades, newRejects, err = l.processOrderList(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, bestInterest, quantityToTrade, order)
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, bestInterest, quantityToTrade, order)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -165,7 +166,7 @@ func (l *Lending) processMarketOrder(createdBlockTime uint64, coinbase common.Ad
 
 // processLimitOrder : process the limit order, can change the quote
 // If not care for performance, we should make a copy of quote to prevent further reference problem
-func (l *Lending) processLimitOrder(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+func (l *Lending) processLimitOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
 	var (
 		trades     []*lendingstate.LendingTrade
 		newTrades  []*lendingstate.LendingTrade
@@ -184,7 +185,7 @@ func (l *Lending) processLimitOrder(createdBlockTime uint64, coinbase common.Add
 		log.Debug("processLimitOrder ", "side", side, "minInterest", minInterest, "orderInterest", Interest, "volume", volume)
 		for quantityToTrade.Cmp(zero) > 0 && Interest.Cmp(minInterest) >= 0 && minInterest.Cmp(zero) > 0 {
 			log.Debug("Min Interest in Investing tree", "Interest", minInterest.String())
-			quantityToTrade, newTrades, newRejects, err = l.processOrderList(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, minInterest, quantityToTrade, order)
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, minInterest, quantityToTrade, order)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -199,7 +200,7 @@ func (l *Lending) processLimitOrder(createdBlockTime uint64, coinbase common.Add
 		log.Debug("processLimitOrder ", "side", side, "maxInterest", maxInterest, "orderInterest", Interest, "volume", volume)
 		for quantityToTrade.Cmp(zero) > 0 && Interest.Cmp(maxInterest) <= 0 && maxInterest.Cmp(zero) > 0 {
 			log.Debug("Max Interest in Borrowing tree", "Interest", maxInterest.String())
-			quantityToTrade, newTrades, newRejects, err = l.processOrderList(createdBlockTime, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, maxInterest, quantityToTrade, order)
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, maxInterest, quantityToTrade, order)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -226,7 +227,7 @@ func (l *Lending) processLimitOrder(createdBlockTime uint64, coinbase common.Add
 }
 
 // processOrderList : process the order list
-func (l *Lending) processOrderList(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, side string, lendingOrderBook common.Hash, Interest *big.Int, quantityStillToTrade *big.Int, order *lendingstate.LendingItem) (*big.Int, []*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+func (l *Lending) processOrderList(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, side string, lendingOrderBook common.Hash, Interest *big.Int, quantityStillToTrade *big.Int, order *lendingstate.LendingItem) (*big.Int, []*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
 	quantityToTrade := lendingstate.CloneBigInt(quantityStillToTrade)
 	log.Debug("Process matching between order and orderlist", "quantityToTrade", quantityToTrade)
 	var (
@@ -262,8 +263,8 @@ func (l *Lending) processOrderList(createdBlockTime uint64, coinbase common.Addr
 			borrowFee = lendingstate.GetFee(statedb, oldestOrder.Relayer)
 		}
 		collateralPrice := common.BasePrice
-		depositRate, liquidationRate, _ := lendingstate.GetCollateralDetail(statedb, collateralToken)
-		lendTokenTOMOPrice, collateralPrice, err := l.GetCollateralPrices(chain, statedb, tradingStateDb, collateralToken, order.LendingToken)
+		depositRate, liquidationRate, _, _, _ := lendingstate.GetCollateralDetail(statedb, collateralToken)
+		lendTokenTOMOPrice, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingStateDb, collateralToken, order.LendingToken)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -323,7 +324,7 @@ func (l *Lending) processOrderList(createdBlockTime uint64, coinbase common.Addr
 			log.Debug("Update quantity for orderId", "orderId", orderId.Hex())
 			log.Debug("LEND", "lendingOrderBook", lendingOrderBook.Hex(), "Taker Interest", Interest, "maker Interest", order.Interest, "Amount", tradedQuantity, "orderId", orderId, "side", side)
 			tradingId := lendingStateDB.GetTradeNonce(lendingOrderBook) + 1
-			liquidationTime := createdBlockTime + order.Term
+			liquidationTime := header.Time.Uint64() + order.Term
 			liquidationPrice := new(big.Int).Mul(collateralPrice, liquidationRate)
 			liquidationPrice = new(big.Int).Div(liquidationPrice, depositRate)
 			lendingTrade := lendingstate.LendingTrade{
@@ -652,7 +653,7 @@ func DoSettleBalance(coinbase common.Address, takerOrder, makerOrder *lendingsta
 	return nil
 }
 
-func (l *Lending) ProcessCancelOrder(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, chain consensus.ChainContext, coinbase common.Address, lendingOrderBook common.Hash, order *lendingstate.LendingItem) (error, bool) {
+func (l *Lending) ProcessCancelOrder(header *types.Header, lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, chain consensus.ChainContext, coinbase common.Address, lendingOrderBook common.Hash, order *lendingstate.LendingItem) (error, bool) {
 	originOrder := lendingStateDB.GetLendingOrder(lendingOrderBook, common.BigToHash(new(big.Int).SetUint64(order.LendingId)))
 	if originOrder == lendingstate.EmptyLendingOrder {
 		return fmt.Errorf("lendingOrder not found. Id: %v. LendToken: %s . Term: %v. CollateralToken: %v", order.LendingId, order.LendingToken.Hex(), order.Term, order.CollateralToken.Hex()), false
@@ -684,7 +685,7 @@ func (l *Lending) ProcessCancelOrder(lendingStateDB *lendingstate.LendingStateDB
 	collateralPrice := common.BasePrice
 
 	if originOrder.Side == lendingstate.Borrowing {
-		_, collateralPrice, err = l.GetCollateralPrices(chain, statedb, tradingStateDb, originOrder.CollateralToken, originOrder.LendingToken)
+		_, collateralPrice, err = l.GetCollateralPrices(header, chain, statedb, tradingStateDb, originOrder.CollateralToken, originOrder.LendingToken)
 		if err != nil {
 			return err, false
 		}
@@ -855,13 +856,15 @@ func (l *Lending) getMediumTradePriceBeforeEpoch(chain consensus.ChainContext, s
 //- Have pairs with TOMO:
 //-  lendToken/TOMO and CollateralToken/TOMO
 //-  TOMO/lendToken and TOMO/CollateralToken
-func (l *Lending) GetCollateralPrices(chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error) {
+func (l *Lending) GetCollateralPrices(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error) {
 	// lendTokenTOMOPrice: price of ticker lendToken/TOMO
 	// collateralTOMOPrice: price of ticker collateralToken/TOMO
 	// collateralPrice: price of ticker collateralToken/lendToken
 
-	_, _, collateralTOMOBasePrice := lendingstate.GetCollateralDetail(statedb, collateralToken)
-	_, _, lendingTOMOBasePrice := lendingstate.GetCollateralDetail(statedb, lendingToken)
+	_, _, collateralTOMOBasePrice, _, collateralUpdatedBlock := lendingstate.GetCollateralDetail(statedb, collateralToken)
+	_, _, lendingTOMOBasePrice, _, lendinglUpdatedBlock := lendingstate.GetCollateralDetail(statedb, lendingToken)
+	collateralPriceUpdatedFromContract := collateralUpdatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
+	lendingTOMOPriceUpdatedFromContract := lendinglUpdatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
 	if lendingToken == common.HexToAddress(common.TomoNativeAddress) {
 		lendingTOMOBasePrice = common.BasePrice
 	}
@@ -874,7 +877,7 @@ func (l *Lending) GetCollateralPrices(chain consensus.ChainContext, statedb *sta
 		return lendTokenTOMOPrice, collateralPrice, err
 	}
 	log.Debug("GetCollateralPrices", "lendTokenTOMOPrice", lendTokenTOMOPrice)
-	if lendTokenTOMOPrice == nil || lendTokenTOMOPrice.Sign() == 0 {
+	if lendTokenTOMOPrice == nil || lendTokenTOMOPrice.Sign() == 0 || lendingTOMOPriceUpdatedFromContract {
 		lendTokenTOMOPrice = lendingTOMOBasePrice
 	}
 	lastMediumPrice, err := l.getMediumTradePriceBeforeEpoch(chain, statedb, tradingStateDb, collateralToken, lendingToken)
@@ -883,14 +886,24 @@ func (l *Lending) GetCollateralPrices(chain consensus.ChainContext, statedb *sta
 	}
 	log.Debug("GetCollateralPrices", "lastMediumPrice", lastMediumPrice, "lendTokenTOMOPrice", lendTokenTOMOPrice)
 	if lastMediumPrice != nil && lastMediumPrice.Sign() > 0 {
-		collateralPrice = lastMediumPrice
+		if collateralPriceUpdatedFromContract && lendingTOMOPriceUpdatedFromContract {
+			lendingTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, common.Address{}, lendingToken)
+			log.Debug("GetTokenDecimal", "lendingToken", lendingToken, "err", err)
+			if err != nil {
+				return nil, nil, err
+			}
+			collateralPrice = new(big.Int).Mul(collateralTOMOBasePrice, lendingTokenDecimal)
+			collateralPrice = new(big.Int).Div(collateralPrice, lendTokenTOMOPrice)
+		} else {
+			collateralPrice = lastMediumPrice
+		}
 	} else {
 		collateralTOMOPrice, err := l.getMediumTradePriceBeforeEpoch(chain, statedb, tradingStateDb, collateralToken, common.HexToAddress(common.TomoNativeAddress))
 		log.Debug("GetCollateralPrices", "collateralTOMOPrice", collateralTOMOPrice, "err", err)
 		if err != nil {
 			return collateralPrice, lendTokenTOMOPrice, err
 		}
-		if collateralTOMOPrice == nil || collateralTOMOPrice.Sign() == 0 {
+		if collateralTOMOPrice == nil || collateralTOMOPrice.Sign() == 0 || collateralPriceUpdatedFromContract {
 			collateralTOMOPrice = collateralTOMOBasePrice
 		}
 		if lendTokenTOMOPrice != nil && lendTokenTOMOPrice.Sign() > 0 {
@@ -958,5 +971,32 @@ func (l *Lending) ProcessTopUpLendingTrade(lendingStateDB *lendingstate.LendingS
 	newLendingTrade.LiquidationPrice = newLiquidationPrice
 	newLendingTrade.CollateralLockedAmount = newLockedAmount
 	log.Debug("ProcessTopUp successfully", "price", newLiquidationPrice, "lockAmount", newLockedAmount)
+	return nil, false, &newLendingTrade
+}
+
+func (l *Lending) ProcessRecallLendingTrade(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, lendingBook common.Hash, lendingTradeId common.Hash, newLiquidationPrice *big.Int) (error, bool, *lendingstate.LendingTrade) {
+	log.Debug("ProcessRecallLendingTrade", "lendingTradeId", lendingTradeId.Hex(), "lendingBook", lendingBook.Hex(), "newLiquidationPrice", newLiquidationPrice)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeId)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return fmt.Errorf("process recall for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex()), true, nil
+	}
+	if newLiquidationPrice.Cmp(lendingTrade.LiquidationPrice) <= 0 {
+		return fmt.Errorf("New liquidation price must higher than  old liquidation price. current liquidation price: %v  , new liquidation price : %v  ", lendingTrade.LiquidationPrice, newLiquidationPrice), true, nil
+	}
+	newLockedAmount := new(big.Int).Mul(lendingTrade.CollateralLockedAmount, lendingTrade.LiquidationPrice)
+	newLockedAmount = new(big.Int).Div(newLockedAmount, newLiquidationPrice)
+	recallAmount := new(big.Int).Sub(lendingTrade.CollateralLockedAmount, newLockedAmount)
+	log.Debug("ProcessRecallLendingTrade", "newLockedAmount", newLockedAmount, "recallAmount", recallAmount, "oldLiquidationPrice", lendingTrade.LiquidationPrice, "newLiquidationPrice", newLiquidationPrice)
+	tradingStateDb.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTrade.TradeId)
+	lendingstate.AddTokenBalance(lendingTrade.Borrower, recallAmount, lendingTrade.CollateralToken, statedb)
+	lendingstate.SubTokenBalance(common.HexToAddress(common.LendingLockAddress), recallAmount, lendingTrade.CollateralToken, statedb)
+
+	lendingStateDB.UpdateLiquidationPrice(lendingBook, lendingTrade.TradeId, newLiquidationPrice)
+	lendingStateDB.UpdateCollateralLockedAmount(lendingBook, lendingTrade.TradeId, newLockedAmount)
+	tradingStateDb.InsertLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), newLiquidationPrice, lendingBook, lendingTrade.TradeId)
+	newLendingTrade := lendingTrade
+	newLendingTrade.LiquidationPrice = newLiquidationPrice
+	newLendingTrade.CollateralLockedAmount = newLockedAmount
+	log.Debug("ProcessRecall", "price", newLiquidationPrice, "lockAmount", newLockedAmount, "recall amount", recallAmount)
 	return nil, false, &newLendingTrade
 }

--- a/tomoxlending/tomoxlending.go
+++ b/tomoxlending/tomoxlending.go
@@ -96,7 +96,7 @@ func (l *Lending) Version() uint64 {
 	return ProtocolVersion
 }
 
-func (l *Lending) ProcessOrderPending(createdBlockTime uint64, coinbase common.Address, chain consensus.ChainContext, pending map[common.Address]types.LendingTransactions, statedb *state.StateDB, lendingStatedb *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB) ([]*lendingstate.LendingItem, map[common.Hash]lendingstate.MatchingResult) {
+func (l *Lending) ProcessOrderPending(header *types.Header, coinbase common.Address, chain consensus.ChainContext, pending map[common.Address]types.LendingTransactions, statedb *state.StateDB, lendingStatedb *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB) ([]*lendingstate.LendingItem, map[common.Hash]lendingstate.MatchingResult) {
 	lendingItems := []*lendingstate.LendingItem{}
 	matchingResults := map[common.Hash]lendingstate.MatchingResult{}
 
@@ -153,7 +153,7 @@ func (l *Lending) ProcessOrderPending(createdBlockTime uint64, coinbase common.A
 			order.Status = lendingstate.LendingStatusCancelled
 		}
 
-		newTrades, newRejectedOrders, err := l.CommitOrder(createdBlockTime, coinbase, chain, statedb, lendingStatedb, tradingStateDb, lendingstate.GetLendingOrderBookHash(order.LendingToken, order.Term), order)
+		newTrades, newRejectedOrders, err := l.CommitOrder(header, coinbase, chain, statedb, lendingStatedb, tradingStateDb, lendingstate.GetLendingOrderBookHash(order.LendingToken, order.Term), order)
 		for _, reject := range newRejectedOrders {
 			log.Debug("Reject order", "reject", *reject)
 		}
@@ -732,7 +732,8 @@ func (l *Lending) RollbackLendingData(txhash common.Hash) error {
 	return nil
 }
 
-func (l *Lending) ProcessLiquidationData(chain consensus.ChainContext, time *big.Int, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (finalizedTrades map[common.Hash]*lendingstate.LendingTrade, err error) {
+func (l *Lending) ProcessLiquidationData(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (finalizedTrades map[common.Hash]*lendingstate.LendingTrade, err error) {
+	time := header.Time
 	allPairs, err := lendingstate.GetAllLendingPairs(statedb)
 	if err != nil {
 		log.Debug("Not found all trading pairs", "error", err)
@@ -766,28 +767,28 @@ func (l *Lending) ProcessLiquidationData(chain consensus.ChainContext, time *big
 		}
 	}
 
-	// liquidate trades by collateralPrice
 	for _, lendingPair := range allPairs {
 		orderbook := tradingstate.GetTradingOrderBookHash(lendingPair.CollateralToken, lendingPair.LendingToken)
-		_, liquidationPrice, err := l.GetCollateralPrices(chain, statedb, tradingState, lendingPair.CollateralToken, lendingPair.LendingToken)
+		_, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingState, lendingPair.CollateralToken, lendingPair.LendingToken)
 		if err != nil {
 			log.Error("Fail when get all trading pairs", "error", err)
 			return map[common.Hash]*lendingstate.LendingTrade{}, err
 		}
-		highestPrice, liquidationData := tradingState.GetHighestLiquidationPriceData(orderbook, liquidationPrice)
-		for highestPrice.Sign() > 0 && liquidationPrice.Cmp(highestPrice) < 0 {
+		// liquidate trades
+		highestLiquidatePrice, liquidationData := tradingState.GetHighestLiquidationPriceData(orderbook, collateralPrice)
+		for highestLiquidatePrice.Sign() > 0 && collateralPrice.Cmp(highestLiquidatePrice) < 0 {
 			for lendingBook, tradingIds := range liquidationData {
 				for _, tradingIdHash := range tradingIds {
 					trade := lendingState.GetLendingTrade(lendingBook, tradingIdHash)
 					if trade.AutoTopUp {
-						if newTrade, err := l.AutoTopUp(statedb, tradingState, lendingState, lendingBook, tradingIdHash, liquidationPrice); err == nil {
+						if newTrade, err := l.AutoTopUp(statedb, tradingState, lendingState, lendingBook, tradingIdHash, collateralPrice); err == nil {
 							// if this action complete successfully, do not liquidate this trade in this epoch
 							log.Debug("AutoTopUp", "borrower", trade.Borrower.Hex(), "collateral", newTrade.CollateralToken.Hex(), "newLockedAmount", newTrade.CollateralLockedAmount)
 							finalizedTrades[newTrade.Hash] = newTrade
 							continue
 						}
 					}
-					log.Debug("LiquidationTrade", "highestPrice", highestPrice, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex())
+					log.Debug("LiquidationTrade", "highestLiquidatePrice", highestLiquidatePrice, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex())
 					newTrade, err := l.LiquidationTrade(lendingState, statedb, tradingState, lendingBook, tradingIdHash.Big().Uint64())
 					if err != nil {
 						log.Error("Fail when remove liquidation newTrade", "time", time, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex(), "error", err)
@@ -799,7 +800,31 @@ func (l *Lending) ProcessLiquidationData(chain consensus.ChainContext, time *big
 					}
 				}
 			}
-			highestPrice, liquidationData = tradingState.GetHighestLiquidationPriceData(orderbook, liquidationPrice)
+			highestLiquidatePrice, liquidationData = tradingState.GetHighestLiquidationPriceData(orderbook, collateralPrice)
+		}
+		// recall trades
+		depositRate, liquidationRate, _, recallRate, _ := lendingstate.GetCollateralDetail(statedb, lendingPair.CollateralToken)
+		recalLiquidatePrice := new(big.Int).Mul(collateralPrice, common.BaseRecall)
+		recalLiquidatePrice = new(big.Int).Div(collateralPrice, recallRate)
+		newLiquidatePrice := new(big.Int).Mul(collateralPrice, liquidationRate)
+		newLiquidatePrice = new(big.Int).Div(newLiquidatePrice, depositRate)
+		lowestLiquidatePrice, liquidationData := tradingState.GetLowestLiquidationPriceData(orderbook, recalLiquidatePrice)
+		log.Debug("ProcessLiquidationData", "recalLiquidatePrice", recalLiquidatePrice, "newLiquidatePrice", newLiquidatePrice, "lowestLiquidatePrice", lowestLiquidatePrice, "liquidationData", liquidationData)
+		for lowestLiquidatePrice.Sign() > 0 && recalLiquidatePrice.Cmp(lowestLiquidatePrice) > 0 {
+			for lendingBook, tradingIds := range liquidationData {
+				for _, tradingIdHash := range tradingIds {
+					trade := lendingState.GetLendingTrade(lendingBook, tradingIdHash)
+					if trade.AutoTopUp {
+						if err, _, newTrade := l.ProcessRecallLendingTrade(lendingState, statedb, tradingState, lendingBook, tradingIdHash, newLiquidatePrice); err == nil {
+							// if this action complete successfully, do not liquidate this trade in this epoch
+							log.Debug("AutoRecall", "borrower", trade.Borrower.Hex(), "collateral", newTrade.CollateralToken.Hex(), "newLockedAmount", newTrade.CollateralLockedAmount)
+							finalizedTrades[newTrade.Hash] = newTrade
+						}
+					}
+					log.Debug("Recall Trade", "lowestLiquidatePrice", lowestLiquidatePrice, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex())
+				}
+			}
+			lowestLiquidatePrice, liquidationData = tradingState.GetLowestLiquidationPriceData(orderbook, recalLiquidatePrice)
 		}
 	}
 

--- a/tomoxlending/tomoxlending.go
+++ b/tomoxlending/tomoxlending.go
@@ -337,7 +337,7 @@ func (l *Lending) SyncDataToSDKNode(takerLendingItem *lendingstate.LendingItem, 
 		"Interest", updatedTakerLendingItem.Interest, "quantity", updatedTakerLendingItem.Quantity, "filledAmount", updatedTakerLendingItem.FilledAmount, "status", updatedTakerLendingItem.Status,
 		"hash", updatedTakerLendingItem.Hash.Hex(), "txHash", updatedTakerLendingItem.TxHash.Hex())
 
-	if !(updatedTakerLendingItem.Type == lendingstate.Repay || updatedTakerLendingItem.Type == lendingstate.TopUp) || updatedTakerLendingItem.Status != lendingstate.LendingStatusOpen {
+	if !(updatedTakerLendingItem.Type == lendingstate.Repay || updatedTakerLendingItem.Type == lendingstate.TopUp || updatedTakerLendingItem.Type == lendingstate.Recall) || updatedTakerLendingItem.Status != lendingstate.LendingStatusOpen {
 		if err := db.PutObject(updatedTakerLendingItem.Hash, updatedTakerLendingItem); err != nil {
 			return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerLendingItem.Hash.Hex(), err.Error())
 		}
@@ -774,9 +774,10 @@ func (l *Lending) RollbackLendingData(txhash common.Hash) error {
 		}
 	}
 
-	// remove repay/topup history
+	// remove repay/topup/recall history
 	db.DeleteItemByTxHash(txhash, &lendingstate.LendingItem{Type: lendingstate.Repay})
 	db.DeleteItemByTxHash(txhash, &lendingstate.LendingItem{Type: lendingstate.TopUp})
+	db.DeleteItemByTxHash(txhash, &lendingstate.LendingItem{Type: lendingstate.Recall})
 
 	if err := db.CommitLendingBulk(); err != nil {
 		return fmt.Errorf("failed to RollbackLendingData. %v", err)


### PR DESCRIPTION
**Changes in this PR:** (resolve #206  resolve #207 )
- core auto recall  & get token price from contract
  - recall when liquidate Price=collateral Price *  100/ recall rate  ~ 50 %
  - update new liquidate Price =  collateral Price * liquidation rate / deposit rate ~ 73%
- Export recall history to database

Testing:
- Send 1 INVEST item, 1 BORROW item in the same pair (BTC/USDT) to generate a lending trade
- Run this script (within from block **checkpoint** to **checkpoint + 100**): tomochain/contracts/tomox/simulation/price/main.go
  - Update USDT/TOMO price to contract
  - Update BTC/TOMO price to contract