### PR TITLE
tomoxlending: refactor repay/topup

### DIFF
--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -540,7 +540,7 @@ func (pool *LendingPool) validateLending(tx *types.LendingTransaction) error {
 	if tx.IsTopupLending() {
 		return pool.validateTopupLending(tx)
 	}
-	if tx.IsRePaymentLending() {
+	if tx.IsRepayLending() {
 		return pool.validateRepayLending(tx)
 	}
 

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -410,6 +410,7 @@ func (pool *LendingPool) GetSender(tx *types.LendingTransaction) (common.Address
 	}
 	return from, nil
 }
+
 func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
 	lendingSide := tx.Side()
 	lendingType := tx.Type()
@@ -430,11 +431,48 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 	if lendingType != LendingTypeLimit && lendingType != LendingTypeMarket {
 		return ErrInvalidLendingType
 	}
-	if valid, _ := lendingstate.IsValidPair(cloneStateDb, tx.RelayerAddress(), tx.LendingToken(), tx.Term()); valid == false {
-		return fmt.Errorf("invalid pair. Relayer: %s. LendingToken: %s. Term: %d", tx.RelayerAddress().Hex(), tx.LendingToken().Hex(), tx.Term())
-	}
-
 	if lendingType == LendingTypeLimit {
+		if err := pool.validateBalance(cloneStateDb, cloneLendingStateDb, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pool *LendingPool) validateCancelledLending(cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
+	if tx.LendingId() == 0 {
+		return ErrInvalidCancelledLending
+	}
+	item := cloneLendingStateDb.GetLendingOrder(lendingstate.GetLendingOrderBookHash(tx.LendingToken(), tx.Term()), common.Uint64ToHash(tx.LendingId()))
+	if item == lendingstate.EmptyLendingOrder {
+		log.Debug("LendingOrder not found ", "LendingId", tx.LendingId(), "LendToken", tx.LendingToken().Hex(), "CollateralToken", tx.CollateralToken().Hex(), "Term", tx.Term())
+		return ErrInvalidCancelledLending
+	}
+	return nil
+}
+func (pool *LendingPool) validateRepayLending(cloneStateDb *state.StateDB, cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
+	if tx.LendingTradeId() == 0 {
+		return ErrInvalidLendingTradeID
+	}
+	if err := pool.validateBalance(cloneStateDb, cloneLendingStateDb, tx); err != nil {
+		return err
+	}
+	return nil
+}
+func (pool *LendingPool) validateTopupLending(cloneStateDb *state.StateDB, cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
+	if tx.LendingTradeId() == 0 {
+		return ErrInvalidLendingTradeID
+	}
+	if tx.Quantity() == nil || tx.Quantity().Sign() <= 0 {
+		return ErrInvalidLendingQuantity
+	}
+	if err := pool.validateBalance(cloneStateDb, cloneLendingStateDb, tx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pool *LendingPool) validateBalance(cloneStateDb *state.StateDB, cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
 		posvEngine, ok := pool.chain.Engine().(*posv.Posv)
 		if !ok {
 			return ErrNotPoSV
@@ -474,6 +512,7 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 		}
 		if err := lendingstate.VerifyBalance(cloneStateDb,
 			cloneLendingStateDb,
+			tx.Type(),
 			tx.Side(),
 			tx.Status(),
 			tx.UserAddress(),
@@ -491,33 +530,6 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 		); err != nil {
 			return fmt.Errorf("VerifyBalance failed ! OrderHash: %s. UserAddress: %s. LendingToken: %s. CollateralToken: %s. Err: %v", tx.Hash().Hex(), tx.UserAddress().Hex(), tx.LendingToken().Hex(), tx.CollateralToken().Hex(), err)
 		}
-	}
-	return nil
-}
-func (pool *LendingPool) validateCancelledLending(cloneLendingStateDb *lendingstate.LendingStateDB, tx *types.LendingTransaction) error {
-	if tx.LendingId() == 0 {
-		return ErrInvalidCancelledLending
-	}
-	item := cloneLendingStateDb.GetLendingOrder(lendingstate.GetLendingOrderBookHash(tx.LendingToken(), tx.Term()), common.Uint64ToHash(tx.LendingId()))
-	if item == lendingstate.EmptyLendingOrder {
-		log.Debug("LendingOrder not found ", "LendingId", tx.LendingId(), "LendToken", tx.LendingToken().Hex(), "CollateralToken", tx.CollateralToken().Hex(), "Term", tx.Term())
-		return ErrInvalidCancelledLending
-	}
-	return nil
-}
-func (pool *LendingPool) validateRepayLending(tx *types.LendingTransaction) error {
-	if tx.LendingTradeId() == 0 {
-		return ErrInvalidLendingTradeID
-	}
-	return nil
-}
-func (pool *LendingPool) validateTopupLending(tx *types.LendingTransaction) error {
-	if tx.LendingTradeId() == 0 {
-		return ErrInvalidLendingTradeID
-	}
-	if tx.Quantity() == nil || tx.Quantity().Sign() <= 0 {
-		return ErrInvalidLendingQuantity
-	}
 	return nil
 }
 
@@ -531,6 +543,9 @@ func (pool *LendingPool) validateLending(tx *types.LendingTransaction) error {
 	if !lendingstate.IsValidRelayer(cloneStateDb, tx.RelayerAddress()) {
 		return fmt.Errorf("invalid lending relayer. ExchangeAddress: %s", tx.RelayerAddress().Hex())
 	}
+	if valid, _ := lendingstate.IsValidPair(cloneStateDb, tx.RelayerAddress(), tx.LendingToken(), tx.Term()); valid == false {
+		return fmt.Errorf("invalid pair. Relayer: %s. LendingToken: %s. Term: %d", tx.RelayerAddress().Hex(), tx.LendingToken().Hex(), tx.Term())
+	}
 	if tx.IsCreatedLending() {
 		return pool.validateNewLending(cloneStateDb, cloneLendingStateDb, tx)
 	}
@@ -538,10 +553,10 @@ func (pool *LendingPool) validateLending(tx *types.LendingTransaction) error {
 		return pool.validateCancelledLending(cloneLendingStateDb, tx)
 	}
 	if tx.IsTopupLending() {
-		return pool.validateTopupLending(tx)
+		return pool.validateTopupLending(cloneStateDb, cloneLendingStateDb,tx)
 	}
 	if tx.IsRepayLending() {
-		return pool.validateRepayLending(tx)
+		return pool.validateRepayLending(cloneStateDb, cloneLendingStateDb,tx)
 	}
 
 	return ErrInvalidLendingStatus

--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -63,39 +63,59 @@ func getLendingNonce(userAddress common.Address) (uint64, error) {
 func (l *LendingMsg) computeHash() common.Hash {
 	borrowing := l.Side == lendingstate.Borrowing
 	sha := sha3.NewKeccak256()
-	if l.Status == lendingstate.LendingStatusCancelled {
-		sha := sha3.NewKeccak256()
-		sha.Write(l.Hash.Bytes())
+	if l.Type == lendingstate.Repay {
 		sha.Write(common.BigToHash(big.NewInt(int64(l.AccountNonce))).Bytes())
-		sha.Write(l.UserAddress.Bytes())
-		sha.Write(common.BigToHash(big.NewInt(int64(l.LendingId))).Bytes())
 		sha.Write([]byte(l.Status))
 		sha.Write(l.RelayerAddress.Bytes())
-	} else if l.Status == lendingstate.LendingStatusNew {
-		sha.Write(l.RelayerAddress.Bytes())
 		sha.Write(l.UserAddress.Bytes())
-		if borrowing {
-			sha.Write(l.CollateralToken.Bytes())
-		}
 		sha.Write(l.LendingToken.Bytes())
-		sha.Write(common.BigToHash(l.Quantity).Bytes())
 		sha.Write(common.BigToHash(big.NewInt(int64(l.Term))).Bytes())
-		if l.Type == lendingstate.Limit {
-			sha.Write(common.BigToHash(big.NewInt(int64(l.Interest))).Bytes())
-		}
-		sha.Write([]byte(l.Side))
-		sha.Write([]byte(l.Status))
-		sha.Write([]byte(l.Type))
-		sha.Write(common.BigToHash(big.NewInt(int64(l.AccountNonce))).Bytes())
 		sha.Write(common.BigToHash(big.NewInt(int64(l.LendingTradeId))).Bytes())
-		if borrowing {
-			autoTopUp := int64(0)
-			if l.AutoTopUp {
-				autoTopUp = int64(1)
+	} else if l.Type == lendingstate.TopUp {
+		sha.Write(common.BigToHash(big.NewInt(int64(l.AccountNonce))).Bytes())
+		sha.Write([]byte(l.Status))
+		sha.Write(l.RelayerAddress.Bytes())
+		sha.Write(l.UserAddress.Bytes())
+		sha.Write(l.LendingToken.Bytes())
+		sha.Write(common.BigToHash(big.NewInt(int64(l.Term))).Bytes())
+		sha.Write(common.BigToHash(big.NewInt(int64(l.LendingTradeId))).Bytes())
+		sha.Write(common.BigToHash(l.Quantity).Bytes())
+	} else {
+		if l.Status == lendingstate.LendingStatusCancelled {
+			sha := sha3.NewKeccak256()
+			sha.Write(l.Hash.Bytes())
+			sha.Write(common.BigToHash(big.NewInt(int64(l.AccountNonce))).Bytes())
+			sha.Write(l.UserAddress.Bytes())
+			sha.Write(common.BigToHash(big.NewInt(int64(l.LendingId))).Bytes())
+			sha.Write([]byte(l.Status))
+			sha.Write(l.RelayerAddress.Bytes())
+		} else if l.Status == lendingstate.LendingStatusNew {
+			sha.Write(l.RelayerAddress.Bytes())
+			sha.Write(l.UserAddress.Bytes())
+			if borrowing {
+				sha.Write(l.CollateralToken.Bytes())
 			}
-			sha.Write(common.BigToHash(big.NewInt(autoTopUp)).Bytes())
+			sha.Write(l.LendingToken.Bytes())
+			sha.Write(common.BigToHash(l.Quantity).Bytes())
+			sha.Write(common.BigToHash(big.NewInt(int64(l.Term))).Bytes())
+			if l.Type == lendingstate.Limit {
+				sha.Write(common.BigToHash(big.NewInt(int64(l.Interest))).Bytes())
+			}
+			sha.Write([]byte(l.Side))
+			sha.Write([]byte(l.Status))
+			sha.Write([]byte(l.Type))
+			sha.Write(common.BigToHash(big.NewInt(int64(l.AccountNonce))).Bytes())
+			sha.Write(common.BigToHash(big.NewInt(int64(l.LendingTradeId))).Bytes())
+			if borrowing {
+				autoTopUp := int64(0)
+				if l.AutoTopUp {
+					autoTopUp = int64(1)
+				}
+				sha.Write(common.BigToHash(big.NewInt(autoTopUp)).Bytes())
+			}
 		}
 	}
+
 	return common.BytesToHash(sha.Sum(nil))
 
 }

--- a/core/types/lending_signing.go
+++ b/core/types/lending_signing.go
@@ -190,7 +190,7 @@ func (lendingsign LendingTxSigner) Hash(tx *LendingTransaction) common.Hash {
 	if tx.IsTopupLending() {
 		return lendingsign.LendingTopUpHash(tx)
 	}
-	if tx.IsRePaymentLending() {
+	if tx.IsRepayLending() {
 		return lendingsign.LendingRepayHash(tx)
 	}
 	return common.Hash{}

--- a/core/types/lending_transaction.go
+++ b/core/types/lending_transaction.go
@@ -86,7 +86,7 @@ type lendingtxdata struct {
 
 // IsCreatedLending check if tx is cancelled transaction
 func (tx *LendingTransaction) IsCreatedLending() bool {
-	if tx.Status() == LendingStatusNew {
+	if tx.IsMoTypeLending() || tx.IsLoTypeLending() {
 		return true
 	}
 	return false
@@ -100,9 +100,9 @@ func (tx *LendingTransaction) IsCancelledLending() bool {
 	return false
 }
 
-// IsRePaymentLending check if tx is repay lending transaction
-func (tx *LendingTransaction) IsRePaymentLending() bool {
-	if tx.Status() == LendingStatusRePay {
+// IsRepayLending check if tx is repay lending transaction
+func (tx *LendingTransaction) IsRepayLending() bool {
+	if tx.Type() == LendingStatusRePay {
 		return true
 	}
 	return false
@@ -110,7 +110,7 @@ func (tx *LendingTransaction) IsRePaymentLending() bool {
 
 // IsTopupLending check if tx is repay lending transaction
 func (tx *LendingTransaction) IsTopupLending() bool {
-	if tx.Status() == LendingStatusTopup {
+	if tx.Type() == LendingStatusTopup {
 		return true
 	}
 	return false

--- a/core/types/lending_transaction.go
+++ b/core/types/lending_transaction.go
@@ -45,8 +45,8 @@ const (
 	LendingTypeLo              = "LO"
 	LendingSideBorrow          = "BORROW"
 	LendingSideInvest          = "INVEST"
-	LendingStatusRePay         = "REPAY"
-	LendingStatusTopup         = "TOPUP"
+	LendingRePay               = "REPAY"
+	LendingTopup               = "TOPUP"
 )
 
 // LendingTransaction lending transaction
@@ -102,7 +102,7 @@ func (tx *LendingTransaction) IsCancelledLending() bool {
 
 // IsRepayLending check if tx is repay lending transaction
 func (tx *LendingTransaction) IsRepayLending() bool {
-	if tx.Type() == LendingStatusRePay {
+	if tx.Type() == LendingRePay {
 		return true
 	}
 	return false
@@ -110,7 +110,7 @@ func (tx *LendingTransaction) IsRepayLending() bool {
 
 // IsTopupLending check if tx is repay lending transaction
 func (tx *LendingTransaction) IsTopupLending() bool {
-	if tx.Type() == LendingStatusTopup {
+	if tx.Type() == LendingTopup {
 		return true
 	}
 	return false

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -278,6 +278,11 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tradingstate.OrderItem, tx
 	)
 	db := tomox.GetMongoDB()
 	db.InitBulk()
+	if takerOrderInTx.Status == tradingstate.OrderStatusCancelled && len(rejectedOrders) > 0 {
+		// cancel order is rejected -> nothing change
+		log.Debug("Cancel order is rejected", "order", tradingstate.ToJSON(takerOrderInTx))
+		return nil
+	}
 	// 1. put processed takerOrderInTx to db
 	lastState := tradingstate.OrderHistoryItem{}
 	val, err := db.GetObject(takerOrderInTx.Hash, &tradingstate.OrderItem{})
@@ -534,7 +539,7 @@ func (tomox *TomoX) HasTradingState(block *types.Block) bool {
 		return false
 	}
 	_, err = tomox.StateCache.OpenTrie(root)
-	if err !=nil{
+	if err != nil {
 		return false
 	}
 	return true

--- a/tomoxDAO/mongodb.go
+++ b/tomoxDAO/mongodb.go
@@ -21,9 +21,9 @@ const (
 	tradesCollection        = "trades"
 	lendingItemsCollection  = "lending_items"
 	lendingTradesCollection = "lending_trades"
-	lendingTopUpCollection  = "lending_topup"
-	lendingRepayCollection  = "lending_repay"
-	epochPriceCollection    = "epoch_price"
+	lendingTopUpCollection  = "lending_topups"
+	lendingRepayCollection  = "lending_repays"
+	epochPriceCollection    = "epoch_prices"
 )
 
 type MongoDatabase struct {
@@ -237,11 +237,19 @@ func (db *MongoDatabase) PutObject(hash common.Hash, val interface{}) error {
 	case *lendingstate.LendingItem:
 		// PutObject order into ordersCollection collection
 		li := val.(*lendingstate.LendingItem)
-		if li.Status == lendingstate.Repay {
+		if li.Type == lendingstate.Repay {
+			if li.Status != lendingstate.LendingStatusReject {
+				li.Status = lendingstate.Repay
+			}
+			li.FilledAmount = li.Quantity
 			db.repayBulk.Insert(li)
 			return nil
 		}
-		if li.Status == lendingstate.TopUp {
+		if li.Type == lendingstate.TopUp {
+			if li.Status != lendingstate.LendingStatusReject {
+				li.Status = lendingstate.TopUp
+			}
+			li.FilledAmount = li.Quantity
 			db.topUpBulk.Insert(li)
 			return nil
 		}

--- a/tomoxlending/lendingstate/lendingitem.go
+++ b/tomoxlending/lendingstate/lendingitem.go
@@ -28,10 +28,15 @@ const (
 )
 
 var ValidInputLendingStatus = map[string]bool{
-	TopUp:                  true,
-	Repay:                  true,
 	LendingStatusNew:       true,
 	LendingStatusCancelled: true,
+}
+
+var ValidInputLendingType = map[string]bool{
+	Market: true,
+	Limit:  true,
+	Repay:  true,
+	TopUp:  true,
 }
 
 // Signature struct
@@ -238,7 +243,7 @@ func (l *LendingItem) VerifyLendingQuantity() error {
 }
 
 func (l *LendingItem) VerifyLendingType() error {
-	if l.Type != Market && l.Type != Limit {
+	if valid, ok := ValidInputLendingType[l.Type]; !ok && !valid {
 		return fmt.Errorf("VerifyLendingType: invalid lending type. Type: %s", l.Type)
 	}
 	return nil

--- a/tomoxlending/lendingstate/lendingitem.go
+++ b/tomoxlending/lendingstate/lendingitem.go
@@ -315,102 +315,108 @@ func (l *LendingItem) VerifyLendingSignature() error {
 }
 
 func VerifyBalance(statedb *state.StateDB, lendingStateDb *LendingStateDB,
-	side, status string, userAddress, relayer, lendingToken, collateralToken common.Address,
+	orderType, side, status string, userAddress, relayer, lendingToken, collateralToken common.Address,
 	quantity, lendingTokenDecimal, collateralTokenDecimal, lendTokenTOMOPrice, collateralPrice *big.Int,
 	term uint64, lendingId uint64, lendingTradeId uint64) error {
 	borrowingFeeRate := GetFee(statedb, relayer)
-	switch side {
-	case Investing:
-		switch status {
-		case LendingStatusNew:
-			// make sure that investor have enough lendingToken
-			if balance := GetTokenBalance(userAddress, lendingToken, statedb); balance.Cmp(quantity) < 0 {
-				return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken. User: %s. Token: %s. Expected: %v. Have: %v", userAddress.Hex(), lendingToken.Hex(), quantity, balance)
-			}
-		case LendingStatusCancelled:
-			// in case of cancel, investor need to pay cancel fee in lendingToken
-			// make sure actualBalance >= cancel fee
-			lendingBook := GetLendingOrderBookHash(lendingToken, term)
-			item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
-			cancelFee := big.NewInt(0)
-			cancelFee = new(big.Int).Mul(item.Quantity, borrowingFeeRate)
-			cancelFee = new(big.Int).Div(cancelFee, common.TomoXBaseCancelFee)
-
-			actualBalance := GetTokenBalance(userAddress, lendingToken, statedb)
-			if actualBalance.Cmp(cancelFee) < 0 {
-				return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken to pay cancel fee. LendingToken: %s . ExpectedBalance: %s . ActualBalance: %s",
-					lendingToken.Hex(), cancelFee.String(), actualBalance.String())
-			}
-		default:
-			return fmt.Errorf("VerifyBalance: invalid status of investing lendingitem. Status: %s", status)
+	switch orderType {
+	case TopUp:
+		lendingBook := GetLendingOrderBookHash(lendingToken, term)
+		lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, common.Uint64ToHash(lendingTradeId))
+		if lendingTrade == EmptyLendingTrade {
+			return fmt.Errorf("VerifyBalance: process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
 		}
-		return nil
-	case Borrowing:
-		switch status {
-		case LendingStatusNew:
-			depositRate, _, _ := GetCollateralDetail(statedb, collateralToken)
-			settleBalanceResult, err := GetSettleBalance(Borrowing, lendTokenTOMOPrice, collateralPrice, depositRate, borrowingFeeRate, lendingToken, collateralToken, lendingTokenDecimal, collateralTokenDecimal, quantity)
-			if err != nil {
-				return err
-			}
-			expectedBalance := settleBalanceResult.CollateralLockedAmount
-			actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
-			if actualBalance.Cmp(expectedBalance) < 0 {
-				return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateral token.  User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
-					userAddress.Hex(), collateralToken.Hex(), expectedBalance.String(), actualBalance.String())
-			}
-		case LendingStatusCancelled:
-			lendingBook := GetLendingOrderBookHash(lendingToken, term)
-			item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
-			cancelFee := big.NewInt(0)
-			// Fee ==  quantityToLend/base lend token decimal *price*borrowFee/LendingCancelFee
-			cancelFee = new(big.Int).Div(item.Quantity, collateralPrice)
-			cancelFee = new(big.Int).Mul(cancelFee, borrowingFeeRate)
-			cancelFee = new(big.Int).Div(cancelFee, common.TomoXBaseCancelFee)
-			actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
-			if actualBalance.Cmp(cancelFee) < 0 {
-				return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateralToken to pay cancel fee. User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
-					userAddress.Hex(), lendingToken.Hex(), cancelFee.String(), actualBalance.String())
-			}
-		case TopUp:
-			lendingBook := GetLendingOrderBookHash(lendingToken, term)
-			lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, common.Uint64ToHash(lendingTradeId))
-			if lendingTrade == EmptyLendingTrade {
-				return fmt.Errorf("VerifyBalance: process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
-			}
-			tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralToken, statedb)
-			if tokenBalance.Cmp(quantity) < 0 {
-				return fmt.Errorf("VerifyBalance: not enough balance to process deposit for lendingTrade."+
-					"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
-					lendingTradeId, lendingTrade.CollateralToken.Hex(), quantity.String(), tokenBalance.String())
-			}
-		case Repay:
-			lendingBook := GetLendingOrderBookHash(lendingToken, term)
-			lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, common.Uint64ToHash(lendingTradeId))
-			if lendingTrade == EmptyLendingTrade {
-				return fmt.Errorf("VerifyBalance: process payment for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
-			}
-			tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.LendingToken, statedb)
-			interestRate := CalculateInterestRate(uint64(time.Now().Unix()), lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest)
-
-			// interest 10%
-			// user should send: 10 * common.BaseLendingInterest
-			// decimal = common.BaseLendingInterest * 100
-			baseInterestDecimal := new(big.Int).Mul(common.BaseLendingInterest, new(big.Int).SetUint64(100))
-
-			paymentBalance := new(big.Int).Mul(lendingTrade.Amount, new(big.Int).Add(baseInterestDecimal, interestRate))
-			paymentBalance = new(big.Int).Div(paymentBalance, baseInterestDecimal)
-			if tokenBalance.Cmp(paymentBalance) < 0 {
-				return fmt.Errorf("VerifyBalance: not enough balance to process payment for lendingTrade."+
-					"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
-					lendingTradeId, lendingTrade.LendingToken.Hex(), paymentBalance.String(), tokenBalance.String())
-
-			}
-		default:
-			return fmt.Errorf("VerifyBalance: invalid status of borrowing lendingitem. Status: %s", status)
+		tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralToken, statedb)
+		if tokenBalance.Cmp(quantity) < 0 {
+			return fmt.Errorf("VerifyBalance: not enough balance to process deposit for lendingTrade."+
+				"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
+				lendingTradeId, lendingTrade.CollateralToken.Hex(), quantity.String(), tokenBalance.String())
 		}
-		return nil
+	case Repay:
+		lendingBook := GetLendingOrderBookHash(lendingToken, term)
+		lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, common.Uint64ToHash(lendingTradeId))
+		if lendingTrade == EmptyLendingTrade {
+			return fmt.Errorf("VerifyBalance: process payment for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
+		}
+		tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.LendingToken, statedb)
+		interestRate := CalculateInterestRate(uint64(time.Now().Unix()), lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest)
+
+		// interest 10%
+		// user should send: 10 * common.BaseLendingInterest
+		// decimal = common.BaseLendingInterest * 100
+		baseInterestDecimal := new(big.Int).Mul(common.BaseLendingInterest, new(big.Int).SetUint64(100))
+
+		paymentBalance := new(big.Int).Mul(lendingTrade.Amount, new(big.Int).Add(baseInterestDecimal, interestRate))
+		paymentBalance = new(big.Int).Div(paymentBalance, baseInterestDecimal)
+		if tokenBalance.Cmp(paymentBalance) < 0 {
+			return fmt.Errorf("VerifyBalance: not enough balance to process payment for lendingTrade."+
+				"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
+				lendingTradeId, lendingTrade.LendingToken.Hex(), paymentBalance.String(), tokenBalance.String())
+
+		}
+	case Market, Limit:
+		switch side {
+		case Investing:
+			switch status {
+			case LendingStatusNew:
+				// make sure that investor have enough lendingToken
+				if balance := GetTokenBalance(userAddress, lendingToken, statedb); balance.Cmp(quantity) < 0 {
+					return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken. User: %s. Token: %s. Expected: %v. Have: %v", userAddress.Hex(), lendingToken.Hex(), quantity, balance)
+				}
+			case LendingStatusCancelled:
+				// in case of cancel, investor need to pay cancel fee in lendingToken
+				// make sure actualBalance >= cancel fee
+				lendingBook := GetLendingOrderBookHash(lendingToken, term)
+				item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
+				cancelFee := big.NewInt(0)
+				cancelFee = new(big.Int).Mul(item.Quantity, borrowingFeeRate)
+				cancelFee = new(big.Int).Div(cancelFee, common.TomoXBaseCancelFee)
+
+				actualBalance := GetTokenBalance(userAddress, lendingToken, statedb)
+				if actualBalance.Cmp(cancelFee) < 0 {
+					return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken to pay cancel fee. LendingToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						lendingToken.Hex(), cancelFee.String(), actualBalance.String())
+				}
+			default:
+				return fmt.Errorf("VerifyBalance: invalid status of investing lendingitem. Status: %s", status)
+			}
+			return nil
+		case Borrowing:
+			switch status {
+			case LendingStatusNew:
+				depositRate, _, _ := GetCollateralDetail(statedb, collateralToken)
+				settleBalanceResult, err := GetSettleBalance(Borrowing, lendTokenTOMOPrice, collateralPrice, depositRate, borrowingFeeRate, lendingToken, collateralToken, lendingTokenDecimal, collateralTokenDecimal, quantity)
+				if err != nil {
+					return err
+				}
+				expectedBalance := settleBalanceResult.CollateralLockedAmount
+				actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
+				if actualBalance.Cmp(expectedBalance) < 0 {
+					return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateral token.  User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						userAddress.Hex(), collateralToken.Hex(), expectedBalance.String(), actualBalance.String())
+				}
+			case LendingStatusCancelled:
+				lendingBook := GetLendingOrderBookHash(lendingToken, term)
+				item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
+				cancelFee := big.NewInt(0)
+				// Fee ==  quantityToLend/base lend token decimal *price*borrowFee/LendingCancelFee
+				cancelFee = new(big.Int).Div(item.Quantity, collateralPrice)
+				cancelFee = new(big.Int).Mul(cancelFee, borrowingFeeRate)
+				cancelFee = new(big.Int).Div(cancelFee, common.TomoXBaseCancelFee)
+				actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
+				if actualBalance.Cmp(cancelFee) < 0 {
+					return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateralToken to pay cancel fee. User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						userAddress.Hex(), lendingToken.Hex(), cancelFee.String(), actualBalance.String())
+				}
+			default:
+				return fmt.Errorf("VerifyBalance: invalid status of borrowing lendingitem. Status: %s", status)
+			}
+			return nil
+		default:
+			return fmt.Errorf("VerifyBalance: unknown lending side")
+		}
 	default:
-		return fmt.Errorf("VerifyBalance: unknown lending side")
+		return fmt.Errorf("VerifyBalance: unknown lending type")
 	}
+	return nil
 }

--- a/tomoxlending/lendingstate/lendingitem_test.go
+++ b/tomoxlending/lendingstate/lendingitem_test.go
@@ -93,8 +93,8 @@ func TestLendingItem_VerifyLendingType(t *testing.T) {
 		{"type: take profit", &LendingItem{Type: "take profit"}, true},
 		{"type: limit", &LendingItem{Type: Limit}, false},
 		{"type: market", &LendingItem{Type: Market}, false},
-                {"type: topup", &LendingItem{Type: TopUp}, false},
-                {"type: repay", &LendingItem{Type: Repay}, false},
+		{"type: topup", &LendingItem{Type: TopUp}, false},
+		{"type: repay", &LendingItem{Type: Repay}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -261,6 +261,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Investing,
+				Type:            Limit,
 				Status:          LendingStatusNew,
 				Quantity:        EtherToWei(big.NewInt(11000)),
 				LendingToken:    lendingToken,
@@ -273,6 +274,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Investing,
+				Type:            Limit,
 				Status:          LendingStatusNew,
 				Quantity:        EtherToWei(big.NewInt(10000)),
 				LendingToken:    lendingToken,
@@ -285,6 +287,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Investing,
+				Type:            Limit,
 				Status:          LendingStatusCancelled,
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
@@ -296,7 +299,8 @@ func TestVerifyBalance(t *testing.T) {
 		{"Invalid status",
 			&LendingItem{
 				Side:   Investing,
-				Status: TopUp,
+				Status: "wrong_status",
+				Type:   Limit,
 			},
 			true,
 		},
@@ -306,6 +310,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
+				Type:            Limit,
 				Status:          LendingStatusNew,
 				Quantity:        EtherToWei(big.NewInt(12000)),
 				LendingToken:    lendingToken,
@@ -319,6 +324,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
+				Type:            Limit,
 				Status:          LendingStatusNew,
 				Quantity:        EtherToWei(big.NewInt(10000)),
 				LendingToken:    lendingToken,
@@ -331,6 +337,7 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
+				Type:            Limit,
 				Status:          LendingStatusCancelled,
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
@@ -344,7 +351,8 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
-				Status:          TopUp,
+				Status:          LendingStatusNew,
+				Type:            TopUp,
 				Quantity:        EtherToWei(big.NewInt(1)),
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
@@ -358,7 +366,8 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
-				Status:          TopUp,
+				Status:          LendingStatusNew,
+				Type:            TopUp,
 				Quantity:        EtherToWei(big.NewInt(1)),
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
@@ -372,7 +381,8 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
-				Status:          Repay,
+				Status:          LendingStatusNew,
+				Type:            Repay,
 				Quantity:        EtherToWei(big.NewInt(1)),
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
@@ -386,7 +396,8 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
-				Status:          Repay,
+				Status:          LendingStatusNew,
+				Type:            Repay,
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
 				Term:            uint64(30),
@@ -400,7 +411,8 @@ func TestVerifyBalance(t *testing.T) {
 				UserAddress:     uAddr,
 				Relayer:         relayer,
 				Side:            Borrowing,
-				Status:          Repay,
+				Status:          LendingStatusNew,
+				Type:            Repay,
 				LendingToken:    lendingToken,
 				CollateralToken: collateralToken,
 				Term:            uint64(30),
@@ -426,6 +438,7 @@ func TestVerifyBalance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := VerifyBalance(statedb,
 				lendingstatedb,
+				tt.fields.Type,
 				tt.fields.Side,
 				tt.fields.Status,
 				tt.fields.UserAddress,
@@ -471,7 +484,7 @@ type LendingOrderMsg struct {
 
 func Test_CreateOrder(t *testing.T) {
 	t.SkipNow()
-	for i := 0; i< 1 ; i++ {
+	for i := 0; i < 1; i++ {
 		sendOrder(uint64(i))
 		time.Sleep(time.Microsecond)
 	}
@@ -493,7 +506,7 @@ func sendOrder(nonce uint64) {
 		CollateralToken: common.HexToAddress("0xC2fa1BA90b15E3612E0067A0020192938784D9C5"),
 		LendingToken:    common.HexToAddress("0x45c25041b8e6CBD5c963E7943007187C3673C7c9"),
 		Interest:        uint64(100),
-		Term:            uint64(30*86400),
+		Term:            uint64(30 * 86400),
 		Status:          LendingStatusNew,
 		Side:            Borrowing,
 		Type:            Limit,

--- a/tomoxlending/lendingstate/lendingitem_test.go
+++ b/tomoxlending/lendingstate/lendingitem_test.go
@@ -93,6 +93,8 @@ func TestLendingItem_VerifyLendingType(t *testing.T) {
 		{"type: take profit", &LendingItem{Type: "take profit"}, true},
 		{"type: limit", &LendingItem{Type: Limit}, false},
 		{"type: market", &LendingItem{Type: Market}, false},
+                {"type: topup", &LendingItem{Type: TopUp}, false},
+                {"type: repay", &LendingItem{Type: Repay}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -119,8 +121,6 @@ func TestLendingItem_VerifyLendingStatus(t *testing.T) {
 		{"status: filled", &LendingItem{Status: LendingStatusFilled}, true},
 		{"status: cancelled", &LendingItem{Status: LendingStatusCancelled}, false},
 		{"status: rejected", &LendingItem{Status: LendingStatusReject}, true},
-		{"status: topup", &LendingItem{Status: TopUp}, false},
-		{"status: repay", &LendingItem{Status: Repay}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tomoxlending/order_processor.go
+++ b/tomoxlending/order_processor.go
@@ -60,13 +60,7 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 		return trades, rejects, nil
 	}
 
-	switch order.Status {
-	case lendingstate.LendingStatusCancelled:
-		err, reject := l.ProcessCancelOrder(lendingStateDB, statedb, tradingStateDb, chain, coinbase, lendingOrderBook, order)
-		if err != nil || reject {
-			rejects = append(rejects, order)
-		}
-		return trades, rejects, nil
+	switch order.Type {
 	case lendingstate.TopUp:
 		err, reject, newLendingTrade := l.ProcessTopUp(lendingStateDB, statedb, tradingStateDb, order)
 		if err != nil || reject {
@@ -85,6 +79,15 @@ func (l *Lending) ApplyOrder(createdBlockTime uint64, coinbase common.Address, c
 		return trades, rejects, nil
 	default:
 	}
+
+	if order.Status == lendingstate.LendingStatusCancelled {
+		err, reject := l.ProcessCancelOrder(lendingStateDB, statedb, tradingStateDb, chain, coinbase, lendingOrderBook, order)
+		if err != nil || reject {
+			rejects = append(rejects, order)
+		}
+		return trades, rejects, nil
+	}
+
 	if order.Type != lendingstate.Market {
 		if order.Interest.Sign() == 0 || common.BigToHash(order.Interest).Big().Cmp(order.Interest) != 0 {
 			log.Debug("Reject order Interest invalid", "Interest", order.Interest)


### PR DESCRIPTION
**Changes in this PR:**
- Type of lendingitem is one of following keywords: MO, LO, REPAY, TOPUP
- ValidatePair, ValidateBalance of REPAY, TOPUP items
- Update repay.hash = trade.hash, topup.hash = trade.hash
- Update collection names as below:
  - epoch_price -> epoch_price**s**
  - lending_repay -> lending_repay**s**
  - lending_topup -> lending_topup**s**
- Update status of repay: REPAY/REJECTED
- Update status of topup: TOPUP/REJECTED
- The cancelled item which is rejected by matching engine won't change status of correspoding lendingitem