### PR TITLE
remove unique index from repay.hash, topup.hash, recall.hash

### DIFF
--- a/tomoxDAO/mongodb.go
+++ b/tomoxDAO/mongodb.go
@@ -641,7 +641,6 @@ func (db *MongoDatabase) EnsureIndexes() error {
 	}
 	repayHashIndex := mgo.Index{
 		Key:        []string{"hash"},
-		Unique:     true,
 		DropDups:   true,
 		Background: true,
 		Sparse:     true,
@@ -657,7 +656,6 @@ func (db *MongoDatabase) EnsureIndexes() error {
 
 	recallHashIndex := mgo.Index{
 		Key:        []string{"hash"},
-		Unique:     true,
 		DropDups:   true,
 		Background: true,
 		Sparse:     true,
@@ -673,7 +671,6 @@ func (db *MongoDatabase) EnsureIndexes() error {
 
 	topupHashIndex := mgo.Index{
 		Key:        []string{"hash"},
-		Unique:     true,
 		DropDups:   true,
 		Background: true,
 		Sparse:     true,


### PR DESCRIPTION
TopUp/ Recall may happen several times on a lending_trades
lending_topups.Hash / lending_recalls.Hash refer to lending_trades.Hash
-> It shouldn't be unique

fix #228 