### PR TITLE
Adding more information to lending_trades, lending_topups, lending_recalls

### DIFF
--- a/consensus/posv/posv.go
+++ b/consensus/posv/posv.go
@@ -87,8 +87,8 @@ type LendingService interface {
 	GetCollateralPrices(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error)
 	GetMediumTradePriceBeforeEpoch(chain consensus.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, baseToken common.Address, quoteToken common.Address) (*big.Int, error)
 	ProcessLiquidationData(header *types.Header, chain consensus.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (updatedTrades map[common.Hash]*lendingstate.LendingTrade, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*lendingstate.LendingTrade, err error)
-	SyncDataToSDKNode(takerOrderInTx *lendingstate.LendingItem, txHash common.Hash, txMatchTime time.Time, trades []*lendingstate.LendingTrade, rejectedOrders []*lendingstate.LendingItem, dirtyOrderCount *uint64) error
-	UpdateLiquidatedTrade(result lendingstate.FinalizedResult, trades map[common.Hash]*lendingstate.LendingTrade) error
+	SyncDataToSDKNode(blockTime uint64, takerOrderInTx *lendingstate.LendingItem, txHash common.Hash, txMatchTime time.Time, trades []*lendingstate.LendingTrade, rejectedOrders []*lendingstate.LendingItem, dirtyOrderCount *uint64) error
+	UpdateLiquidatedTrade(blockTime uint64, result lendingstate.FinalizedResult, trades map[common.Hash]*lendingstate.LendingTrade) error
 	RollbackLendingData(txhash common.Hash) error
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2648,7 +2648,7 @@ func (bc *BlockChain) logLendingData(block *types.Block) {
 			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
 			milliSecond := batch.Timestamp / 1e6
 			txMatchTime := time.Unix(0, milliSecond*1e6).UTC()
-			if err := lendingService.SyncDataToSDKNode(item, batch.TxHash, txMatchTime, trades, rejectedOrders, &dirtyOrderCount); err != nil {
+			if err := lendingService.SyncDataToSDKNode(block.Time().Uint64(), item, batch.TxHash, txMatchTime, trades, rejectedOrders, &dirtyOrderCount); err != nil {
 				log.Crit("lending: failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 			}
 		}
@@ -2666,7 +2666,7 @@ func (bc *BlockChain) logLendingData(block *types.Block) {
 			finalizedTrades = finalizedData.(map[common.Hash]*lendingstate.LendingTrade)
 		}
 		if len(finalizedTrades) > 0 {
-			if err := lendingService.UpdateLiquidatedTrade(finalizedTx, finalizedTrades); err != nil {
+			if err := lendingService.UpdateLiquidatedTrade(block.Time().Uint64(), finalizedTx, finalizedTrades); err != nil {
 				log.Crit("lending: failed to UpdateLiquidatedTrade ", "blockNumber", block.Number(), "err", err)
 			}
 		}

--- a/tomoxlending/lendingstate/lendingitem.go
+++ b/tomoxlending/lendingstate/lendingitem.go
@@ -345,15 +345,8 @@ func VerifyBalance(statedb *state.StateDB, lendingStateDb *LendingStateDB,
 			return fmt.Errorf("VerifyBalance: process payment for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
 		}
 		tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.LendingToken, statedb)
-		interestRate := CalculateInterestRate(uint64(time.Now().Unix()), lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest)
+		paymentBalance := CalculateTotalRepayValue(uint64(time.Now().Unix()), lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest, lendingTrade.Amount)
 
-		// interest 10%
-		// user should send: 10 * common.BaseLendingInterest
-		// decimal = common.BaseLendingInterest * 100
-		baseInterestDecimal := new(big.Int).Mul(common.BaseLendingInterest, new(big.Int).SetUint64(100))
-
-		paymentBalance := new(big.Int).Mul(lendingTrade.Amount, new(big.Int).Add(baseInterestDecimal, interestRate))
-		paymentBalance = new(big.Int).Div(paymentBalance, baseInterestDecimal)
 		if tokenBalance.Cmp(paymentBalance) < 0 {
 			return fmt.Errorf("VerifyBalance: not enough balance to process payment for lendingTrade."+
 				"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",

--- a/tomoxlending/lendingstate/settle_balance.go
+++ b/tomoxlending/lendingstate/settle_balance.go
@@ -75,7 +75,7 @@ func GetSettleBalance(takerSide string,
 			defaultFeeInTOMO := new(big.Int).Mul(defaultFee, lendTokenTOMOPrice)
 			defaultFeeInTOMO = new(big.Int).Div(defaultFeeInTOMO, lendTokenDecimal)
 
-			if (exTakerReceivedFee.Cmp(common.RelayerLendingFee) <= 0 && exTakerReceivedFee.Sign() > 0 ) || defaultFeeInTOMO.Cmp(common.RelayerLendingFee) <= 0 {
+			if (exTakerReceivedFee.Cmp(common.RelayerLendingFee) <= 0 && exTakerReceivedFee.Sign() > 0) || defaultFeeInTOMO.Cmp(common.RelayerLendingFee) <= 0 {
 				log.Debug("takerFee too small", "quantityToLend", quantityToLend, "takerFee", takerFee, "exTakerReceivedFee", exTakerReceivedFee, "borrowFee", borrowFee, "defaultFeeInTOMO", defaultFeeInTOMO)
 				return result, ErrQuantityTradeTooSmall
 			}
@@ -175,4 +175,16 @@ func CalculateInterestRate(finalizeTime, liquidationTime, term uint64, apr uint6
 	interestRate = new(big.Int).Mul(interestRate, timeToPayInterest)
 	interestRate = new(big.Int).Div(interestRate, new(big.Int).SetUint64(common.OneYear))
 	return interestRate
+}
+
+func CalculateTotalRepayValue(finalizeTime, liquidationTime, term uint64, apr uint64, tradeAmount *big.Int) *big.Int {
+	interestRate := CalculateInterestRate(finalizeTime, liquidationTime, term, apr)
+
+	// interest 10%
+	// user should send: 10 * common.BaseLendingInterest
+	// decimal = common.BaseLendingInterest * 100
+	baseInterestDecimal := new(big.Int).Mul(common.BaseLendingInterest, new(big.Int).SetUint64(100))
+	paymentBalance := new(big.Int).Mul(tradeAmount, new(big.Int).Add(baseInterestDecimal, interestRate))
+	paymentBalance = new(big.Int).Div(paymentBalance, baseInterestDecimal)
+	return paymentBalance
 }

--- a/tomoxlending/lendingstate/trade.go
+++ b/tomoxlending/lendingstate/trade.go
@@ -36,6 +36,7 @@ type LendingTrade struct {
 	LiquidationTime        uint64         `bson:"liquidationTime" json:"liquidationTime"`
 	DepositRate            *big.Int       `bson:"depositRate" json:"depositRate"`
 	LiquidationRate        *big.Int       `bson:"liquidationRate" json:"liquidationRate"`
+	RecallRate             *big.Int       `bson:"recallRate" json:"recallRate"`
 	Amount                 *big.Int       `bson:"amount" json:"amount"`
 	BorrowingFee           *big.Int       `bson:"borrowingFee" json:"borrowingFee"`
 	InvestingFee           *big.Int       `bson:"investingFee" json:"investingFee"`
@@ -69,6 +70,7 @@ type LendingTradeBSON struct {
 	AutoTopUp              bool      `bson:"autoTopUp" json:"autoTopUp"`
 	DepositRate            string    `bson:"depositRate" json:"depositRate"`
 	LiquidationRate        string    `bson:"liquidationRate" json:"liquidationRate"`
+	RecallRate             string    `bson:"recallRate" json:"recallRate"`
 	Amount                 string    `bson:"amount" json:"amount"`
 	BorrowingFee           string    `bson:"borrowingFee" json:"borrowingFee"`
 	InvestingFee           string    `bson:"investingFee" json:"investingFee"`
@@ -106,6 +108,7 @@ func (t *LendingTrade) GetBSON() (interface{}, error) {
 			AutoTopUp:              t.AutoTopUp,
 			DepositRate:            t.DepositRate.String(),
 			LiquidationRate:        t.LiquidationRate.String(),
+			RecallRate:             t.RecallRate.String(),
 			Amount:                 t.Amount.String(),
 			BorrowingFee:           t.BorrowingFee.String(),
 			InvestingFee:           t.InvestingFee.String(),
@@ -163,6 +166,7 @@ func (t *LendingTrade) SetBSON(raw bson.Raw) error {
 	t.CollateralLockedAmount = ToBigInt(decoded.CollateralLockedAmount)
 	t.DepositRate = ToBigInt(decoded.DepositRate)
 	t.LiquidationRate = ToBigInt(decoded.LiquidationRate)
+	t.RecallRate = ToBigInt(decoded.RecallRate)
 	t.Amount = tradingstate.ToBigInt(decoded.Amount)
 	t.BorrowingFee = tradingstate.ToBigInt(decoded.BorrowingFee)
 	t.InvestingFee = tradingstate.ToBigInt(decoded.InvestingFee)

--- a/tomoxlending/lendingstate/trade.go
+++ b/tomoxlending/lendingstate/trade.go
@@ -35,6 +35,7 @@ type LendingTrade struct {
 	AutoTopUp              bool           `bson:"autoTopUp" json:"autoTopUp"`
 	LiquidationTime        uint64         `bson:"liquidationTime" json:"liquidationTime"`
 	DepositRate            *big.Int       `bson:"depositRate" json:"depositRate"`
+	LiquidationRate        *big.Int       `bson:"liquidationRate" json:"liquidationRate"`
 	Amount                 *big.Int       `bson:"amount" json:"amount"`
 	BorrowingFee           *big.Int       `bson:"borrowingFee" json:"borrowingFee"`
 	InvestingFee           *big.Int       `bson:"investingFee" json:"investingFee"`
@@ -67,6 +68,7 @@ type LendingTradeBSON struct {
 	CollateralLockedAmount string    `bson:"collateralLockedAmount" json:"collateralLockedAmount"`
 	AutoTopUp              bool      `bson:"autoTopUp" json:"autoTopUp"`
 	DepositRate            string    `bson:"depositRate" json:"depositRate"`
+	LiquidationRate        string    `bson:"liquidationRate" json:"liquidationRate"`
 	Amount                 string    `bson:"amount" json:"amount"`
 	BorrowingFee           string    `bson:"borrowingFee" json:"borrowingFee"`
 	InvestingFee           string    `bson:"investingFee" json:"investingFee"`
@@ -103,6 +105,7 @@ func (t *LendingTrade) GetBSON() (interface{}, error) {
 			CollateralLockedAmount: t.CollateralLockedAmount.String(),
 			AutoTopUp:              t.AutoTopUp,
 			DepositRate:            t.DepositRate.String(),
+			LiquidationRate:        t.LiquidationRate.String(),
 			Amount:                 t.Amount.String(),
 			BorrowingFee:           t.BorrowingFee.String(),
 			InvestingFee:           t.InvestingFee.String(),
@@ -159,6 +162,7 @@ func (t *LendingTrade) SetBSON(raw bson.Raw) error {
 	t.LiquidationTime = uint64(liquidationTime)
 	t.CollateralLockedAmount = ToBigInt(decoded.CollateralLockedAmount)
 	t.DepositRate = ToBigInt(decoded.DepositRate)
+	t.LiquidationRate = ToBigInt(decoded.LiquidationRate)
 	t.Amount = tradingstate.ToBigInt(decoded.Amount)
 	t.BorrowingFee = tradingstate.ToBigInt(decoded.BorrowingFee)
 	t.InvestingFee = tradingstate.ToBigInt(decoded.InvestingFee)

--- a/tomoxlending/order_processor.go
+++ b/tomoxlending/order_processor.go
@@ -337,6 +337,7 @@ func (l *Lending) processOrderList(header *types.Header, coinbase common.Address
 				LiquidationPrice:       liquidationPrice,
 				Interest:               oldestOrder.Interest.Uint64(),
 				DepositRate:            depositRate,
+				LiquidationRate: liquidationRate,
 				CollateralLockedAmount: collateralLockedAmount,
 			}
 			lendingTrade.Status = lendingstate.TradeStatusOpen

--- a/tomoxlending/order_processor.go
+++ b/tomoxlending/order_processor.go
@@ -263,7 +263,7 @@ func (l *Lending) processOrderList(header *types.Header, coinbase common.Address
 			borrowFee = lendingstate.GetFee(statedb, oldestOrder.Relayer)
 		}
 		collateralPrice := common.BasePrice
-		depositRate, liquidationRate, _ := lendingstate.GetCollateralDetail(statedb, collateralToken)
+		depositRate, liquidationRate, recallRate := lendingstate.GetCollateralDetail(statedb, collateralToken)
 		lendTokenTOMOPrice, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingStateDb, collateralToken, order.LendingToken)
 		if err != nil {
 			return nil, nil, nil, err
@@ -337,7 +337,8 @@ func (l *Lending) processOrderList(header *types.Header, coinbase common.Address
 				LiquidationPrice:       liquidationPrice,
 				Interest:               oldestOrder.Interest.Uint64(),
 				DepositRate:            depositRate,
-				LiquidationRate: liquidationRate,
+				LiquidationRate:        liquidationRate,
+				RecallRate:             recallRate,
 				CollateralLockedAmount: collateralLockedAmount,
 			}
 			lendingTrade.Status = lendingstate.TradeStatusOpen


### PR DESCRIPTION
**Changes in this PR:**
- Adding `liquidationRate`, `recallRate` to lending_trades
![image](https://user-images.githubusercontent.com/17243442/79180616-961b6b80-7e34-11ea-9360-8d736f3257a4.png)
- `lending_repays.quantity = trade.Amount + interestValue`
- Adding current collateralPrice to topup/recall items

```
{
    "_id" : ObjectId("5e93ea2695e6a07ae1cc4f20"),
    "quantity" : "100000000",
    "interest" : "1000000000",
    "side" : "BORROW",
    "type" : "TOPUP",
    "lendingToken" : "0x45c25041b8e6CBD5c963E7943007187C3673C7c9",
    "collateralToken" : "0xC2fa1BA90b15E3612E0067A0020192938784D9C5",
    "autoTopUp" : true,
    "filledAmount" : "100000000",
    "status" : "TOPUP",
    "relayer" : "0x0D3ab14BBaD3D99F4203bd7a11aCB94882050E7e",
    "term" : "86400",
    "userAddress" : "0x17F2beD710ba50Ed27aEa52fc4bD7Bda5ED4a037",
    "signature" : {
        "v" : 28,
        "r" : "0x16ba7ee3b237061c2edabbd1eeebdb08a03972c6d372da24646aaa884074f31b",
        "s" : "0x2e6551505310d7cf045bff6e83f68dbb44e9f46639c9490814a5a7a460d136b0"
    },
    "hash" : "0x0caed54fee0e7ea1f1dd1b231fb1f30cd2d8bd29003b5826ac8b0e5f6f44c5b4",
    "txHash" : "0x275c17ca195cdcadf8e555502445da0d6ded95993e7d2fcee5143b6010d3d703",
    "nonce" : "2",
    "createdAt" : ISODate("2020-04-13T04:09:47.002Z"),
    "updatedAt" : ISODate("2020-04-13T04:09:47.002Z"),
    "lendingId" : "0",
    "tradeId" : "1",
    "extraData" : "{\"Auto\":false,\"Price\":727043749643}"
}
```