### PR TITLE
Validate token applying to TomoZ/TomoX

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -93,6 +93,20 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 				return nil, nil, 0, fmt.Errorf("Block contains transaction with receiver in black-list: %v", tx.To().Hex())
 			}
 		}
+		// validate minFee slot for TomoZ
+		if tx.IsTomoZApplyTransaction() {
+			copyState := statedb.Copy()
+			if err := ValidateTomoZApplyTransaction(p.bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				return nil, nil, 0, err
+			}
+		}
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+			copyState := statedb.Copy()
+			if err := ValidateTomoXApplyTransaction(p.bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				return nil, nil, 0, err
+			}
+		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 		receipt, gas, err, tokenFeeUsed := ApplyTransaction(p.config, balanceFee, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
 		if err != nil {
@@ -155,6 +169,20 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 			// check if receiver is in black list
 			if tx.To() != nil && common.Blacklist[*tx.To()] {
 				return nil, nil, 0, fmt.Errorf("Block contains transaction with receiver in black-list: %v", tx.To().Hex())
+			}
+		}
+		// validate minFee slot for TomoZ
+		if tx.IsTomoZApplyTransaction() {
+			copyState := statedb.Copy()
+			if err := ValidateTomoZApplyTransaction(p.bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				return nil, nil, 0, err
+			}
+		}
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+			copyState := statedb.Copy()
+			if err := ValidateTomoXApplyTransaction(p.bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				return nil, nil, 0, err
 			}
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -120,6 +120,9 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 
 // make sure that balance of token is at slot 0
 func ValidateTomoXApplyTransaction(chain consensus.ChainContext, copyState *state.StateDB, tokenAddr common.Address) error {
+	if !chain.Config().IsTIPTomoX(chain.CurrentHeader().Number) {
+		return nil
+	}
 	contractABI, err := GetTokenAbi(contract.TRC21ABI)
 	if err != nil {
 		return fmt.Errorf("ValidateTomoXApplyTransaction: cannot parse ABI. Err: %v", err)
@@ -136,6 +139,9 @@ func ValidateTomoXApplyTransaction(chain consensus.ChainContext, copyState *stat
 // make sure that balance of token is at slot 0
 // make sure that minFee of token is at slot 1
 func ValidateTomoZApplyTransaction(chain consensus.ChainContext, copyState *state.StateDB, tokenAddr common.Address) error {
+	if !chain.Config().IsTIPTomoX(chain.CurrentHeader().Number) {
+		return nil
+	}
 	contractABI, err := GetTokenAbi(contract.TRC21ABI)
 	if err != nil {
 		return fmt.Errorf("ValidateTomoZApplyTransaction: cannot parse ABI. Err: %v", err)

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	balanceOfFunction = "balanceOf"
-	minFeeFunction    = "minFee"
+	balanceOfFunction  = "balanceOf"
+	minFeeFunction     = "minFee"
+	getDecimalFunction = "decimals"
 )
 
 // callmsg implements core.Message to allow passing it as a transaction simulator.
@@ -121,9 +122,12 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 func ValidateTomoXApplyTransaction(chain consensus.ChainContext, copyState *state.StateDB, tokenAddr common.Address) error {
 	contractABI, err := GetTokenAbi(contract.TRC21ABI)
 	if err != nil {
-		return fmt.Errorf("ValidateTomoZApplyTransaction: cannot parse ABI. Err: %v", err)
+		return fmt.Errorf("ValidateTomoXApplyTransaction: cannot parse ABI. Err: %v", err)
 	}
 	if err := ValidateBalanceSlot(chain, copyState, tokenAddr, contractABI); err != nil {
+		return err
+	}
+	if err := ValidateTokenDecimal(chain, copyState, tokenAddr, contractABI); err != nil {
 		return err
 	}
 	return nil
@@ -168,7 +172,7 @@ func ValidateBalanceSlot(chain consensus.ChainContext, copyState *state.StateDB,
 		return fmt.Errorf("invalid balance at slot %v . Token: %s . GotBalance: %v . ResultType: %T", state.SlotTRC21Token["balances"], tokenAddr.Hex(), result, result)
 	}
 	if balance.Cmp(randBalance) != 0 {
-		log.Debug("ValidateTomoZApplyTransaction", "balance_set_at_slot_0", randBalance, "balance_get_from_abi", balance)
+		log.Debug("invalid balance slot", "balance_set_at_slot_0", randBalance, "balance_get_from_abi", balance)
 		return fmt.Errorf("invalid balance slot. Token: %s", tokenAddr.Hex())
 	}
 	return nil
@@ -188,8 +192,16 @@ func ValidateMinFeeSlot(chain consensus.ChainContext, copyState *state.StateDB, 
 		return fmt.Errorf("invalid minFee at slot %v . Token: %s . GotMinFee: %v . ResultType: %T", state.SlotTRC21Token["minFee"], tokenAddr.Hex(), result, result)
 	}
 	if minFee.Cmp(randomValue) != 0 {
-		log.Debug("ValidateTomoZApplyTransaction", "minFee_set_at_slot_1", randomValue, "minFee_get_from_abi", minFee)
+		log.Debug("invalid minFee slot", "minFee_set_at_slot_1", randomValue, "minFee_get_from_abi", minFee)
 		return fmt.Errorf("invalid minFee slot. Token: %s", tokenAddr.Hex())
+	}
+	return nil
+}
+
+func ValidateTokenDecimal(chain consensus.ChainContext, copyState *state.StateDB, tokenAddr common.Address, contractABI *abi.ABI) error {
+	result, err := RunContract(chain, copyState, tokenAddr, contractABI, getDecimalFunction)
+	if err != nil || result == nil {
+		return fmt.Errorf("cannot get token decimal. Token: %s . Err: %v", tokenAddr.Hex(), err)
 	}
 	return nil
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -674,11 +674,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrMinDeploySMC
 	}
 
+	// validate minFee slot for TomoZ
 	if tx.IsTomoZApplyTransaction() {
 		copyState := pool.currentState.Copy()
 		return ValidateTomoZApplyTransaction(pool.chain, copyState, common.BytesToAddress(tx.Data()[4:]))
 	}
 
+	// validate balance slot, token decimal for TomoX
 	if tx.IsTomoXApplyTransaction() {
 		copyState := pool.currentState.Copy()
 		return ValidateTomoXApplyTransaction(pool.chain, copyState, common.BytesToAddress(tx.Data()[4:]))

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -353,6 +353,21 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 		return fmt.Errorf("Reject transaction with receiver in black-list: %v", tx.To().Hex())
 	}
 
+	// validate minFee slot for TomoZ
+	if tx.IsTomoZApplyTransaction() {
+		copyState := pool.currentState(ctx).Copy()
+		if err := core.ValidateTomoZApplyTransaction(pool.chain, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+			return err
+		}
+	}
+	// validate balance slot, token decimal for TomoX
+	if tx.IsTomoXApplyTransaction() {
+		copyState := pool.currentState(ctx).Copy()
+		if err := core.ValidateTomoXApplyTransaction(pool.chain, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+			return err
+		}
+	}
+
 	// Validate the transaction sender and it's sig. Throw
 	// if the from fields is invalid.
 	if from, err = types.Sender(pool.signer, tx); err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -851,6 +851,25 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 			}
 		}
 
+		// validate minFee slot for TomoZ
+		if tx.IsTomoZApplyTransaction() {
+			copyState, _ := bc.State()
+			if err := core.ValidateTomoZApplyTransaction(bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				log.Debug("TomoZApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+				txs.Pop()
+				continue
+			}
+		}
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+			copyState, _ := bc.State()
+			if err := core.ValidateTomoXApplyTransaction(bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+				txs.Pop()
+				continue
+			}
+		}
+
 		if gp.Gas() < params.TxGas && tx.Gas() > 0 {
 			log.Trace("Not enough gas for further transactions", "gp", gp)
 			break
@@ -943,6 +962,25 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 			if tx.To() != nil && common.Blacklist[*tx.To()] {
 				log.Debug("Skipping transaction with receiver in black-list", "receiver", tx.To().Hex())
 				txs.Shift()
+				continue
+			}
+		}
+
+		// validate minFee slot for TomoZ
+		if tx.IsTomoZApplyTransaction() {
+			copyState, _ := bc.State()
+			if err := core.ValidateTomoZApplyTransaction(bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				log.Debug("TomoZApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+				txs.Pop()
+				continue
+			}
+		}
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+			copyState, _ := bc.State()
+			if err := core.ValidateTomoXApplyTransaction(bc, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+				txs.Pop()
 				continue
 			}
 		}

--- a/tomoxlending/tomoxlending.go
+++ b/tomoxlending/tomoxlending.go
@@ -870,7 +870,8 @@ func (l *Lending) ProcessLiquidationData(header *types.Header, chain consensus.C
 		_, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingState, lendingPair.CollateralToken, lendingPair.LendingToken)
 		if err != nil {
 			log.Error("Fail when get all trading pairs", "error", err)
-			return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err
+			// ignore this pair, do not throw error
+			continue
 		}
 		// liquidate trades
 		highestLiquidatePrice, liquidationData := tradingState.GetHighestLiquidationPriceData(orderbook, collateralPrice)


### PR DESCRIPTION
**Changes in this PR:**
- Validate token decimal fin TomoXListing tx
- Validate token applying to TomoZ/TomoX not only in `tx_pool` but also in `miner/worker`, `ApplyTransaction`
- Fix chain stop issue in tomoxlending if fail to get token decimals

This fixes #235 