### PR TITLE
Handle error in parsing txmatch

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -126,6 +126,7 @@ var Blacklist = map[Address]bool{
 	HexToAddress("0xfe685f43acc62f92ab01a8da80d76455d39d3cb3"): true,
 	HexToAddress("0x3538a544021c07869c16b764424c5987409cba48"): true,
 	HexToAddress("0xe187cf86c2274b1f16e8225a7da9a75aba4f1f5f"): true,
+	HexToAddress("0x0000000000000000000000000000000000000011"): true,
 }
 var TIPTRC21Fee = big.NewInt(13523400)
 var LimitTimeFinality = uint64(30) // limit in 30 block

--- a/consensus/posv/posv.go
+++ b/consensus/posv/posv.go
@@ -64,9 +64,9 @@ type Masternode struct {
 }
 
 type TradingService interface {
-	GetTradingStateRoot(block *types.Block) (common.Hash, error)
-	GetTradingState(block *types.Block) (*tradingstate.TradingStateDB, error)
-	HasTradingState(block *types.Block) bool
+	GetTradingStateRoot(block *types.Block, author common.Address) (common.Hash, error)
+	GetTradingState(block *types.Block, author common.Address) (*tradingstate.TradingStateDB, error)
+	HasTradingState(block *types.Block, author common.Address) bool
 	GetStateCache() tradingstate.Database
 	GetTriegc() *prque.Prque
 	ApplyOrder(coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, tomoXstatedb *tradingstate.TradingStateDB, orderBook common.Hash, order *tradingstate.OrderItem) ([]map[string]string, []*tradingstate.OrderItem, error)
@@ -78,9 +78,9 @@ type TradingService interface {
 }
 
 type LendingService interface {
-	GetLendingStateRoot(block *types.Block) (common.Hash, error)
-	GetLendingState(block *types.Block) (*lendingstate.LendingStateDB, error)
-	HasLendingState(block *types.Block) bool
+	GetLendingStateRoot(block *types.Block, author common.Address) (common.Hash, error)
+	GetLendingState(block *types.Block, author common.Address) (*lendingstate.LendingStateDB, error)
+	HasLendingState(block *types.Block, author common.Address) bool
 	GetStateCache() lendingstate.Database
 	GetTriegc() *prque.Prque
 	ApplyOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error)

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -120,7 +120,8 @@ func (v *BlockValidator) ValidateTradingOrder(statedb *state.StateDB, tomoxState
 		// verify orderItem
 		order, err := txMatch.DecodeOrder()
 		if err != nil {
-			return fmt.Errorf("transaction match is corrupted. Failed decode order. Error: %s ", err)
+			log.Error("transaction match is corrupted. Failed decode order", "err", err)
+			continue
 		}
 
 		log.Debug("process tx match", "order", order)
@@ -212,7 +213,8 @@ func ExtractTradingTransactions(transactions types.Transactions) ([]tradingstate
 		if tx.IsTradingTransaction() {
 			txMatchBatch, err := tradingstate.DecodeTxMatchesBatch(tx.Data())
 			if err != nil {
-				return []tradingstate.TxMatchBatch{}, fmt.Errorf("transaction match is corrupted. Failed to decode txMatchBatch. Error: %s", err)
+				log.Error("transaction match is corrupted. Failed to decode txMatchBatch", "err", err, "txHash", tx.Hash().Hex())
+				continue
 			}
 			txMatchBatch.TxHash = tx.Hash()
 			txMatchBatchData = append(txMatchBatchData, txMatchBatch)
@@ -227,7 +229,8 @@ func ExtractLendingTransactions(transactions types.Transactions) ([]lendingstate
 		if tx.IsLendingTransaction() {
 			txMatchBatch, err := lendingstate.DecodeTxLendingBatch(tx.Data())
 			if err != nil {
-				return []lendingstate.TxLendingBatch{}, fmt.Errorf("transaction match is corrupted. Failed to decode lendingTransaction. Error: %s", err)
+				log.Error("transaction match is corrupted. Failed to decode lendingTransaction", "err", err, "txHash", tx.Hash().Hex())
+				continue
 			}
 			txMatchBatch.TxHash = tx.Hash()
 			batchData = append(batchData, txMatchBatch)
@@ -241,7 +244,8 @@ func ExtractLendingFinalizedTradeTransactions(transactions types.Transactions) (
 		if tx.IsLendingFinalizedTradeTransaction() {
 			finalizedTrades, err := lendingstate.DecodeFinalizedResult(tx.Data())
 			if err != nil {
-				return lendingstate.FinalizedResult{}, fmt.Errorf("transaction is corrupted. Failed to decode LendingClosedTradeTransaction. Error: %s", err)
+				log.Error("transaction is corrupted. Failed to decode LendingClosedTradeTransaction", "err", err, "txHash", tx.Hash().Hex())
+				continue
 			}
 			finalizedTrades.TxHash = tx.Hash()
 			// each block has only one tx of this type

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -527,7 +527,11 @@ func (pool *LendingPool) validateBalance(cloneStateDb *state.StateDB, cloneLendi
 	if err != nil {
 		return fmt.Errorf("validateOrder: failed to get lendingTokenDecimal. err: %v", err)
 	}
-	tradingStateDb, err := tomoXServ.GetTradingState(pool.chain.CurrentBlock())
+	author, err :=  pool.chain.Engine().Author(pool.chain.CurrentHeader())
+	if err!= nil {
+		return err
+	}
+	tradingStateDb, err := tomoXServ.GetTradingState(pool.chain.CurrentBlock(), author)
 	if err != nil {
 		return fmt.Errorf("validateLending: failed to get tradingStateDb. Error: %v", err)
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -427,7 +427,11 @@ func (b *EthApiBackend) AreTwoBlockSamePath(bh1 common.Hash, bh2 common.Hash) bo
 func (b *EthApiBackend) GetOrderNonce(address common.Hash) (uint64, error) {
 	tomoxService := b.eth.GetTomoX()
 	if tomoxService != nil {
-		tomoxState, err := tomoxService.GetTradingState(b.CurrentBlock())
+		author, err := b.GetEngine().Author(b.CurrentBlock().Header())
+		if err != nil {
+			return 0, err
+		}
+		tomoxState, err := tomoxService.GetTradingState(b.CurrentBlock(), author)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2045,8 +2045,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBestBid(ctx context.Context, baseToke
 	if tomoxService == nil {
 		return result, errors.New("TomoX service not found")
 	}
-
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return result, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return result, err
 	}
@@ -2067,8 +2070,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBestAsk(ctx context.Context, baseToke
 	if tomoxService == nil {
 		return result, errors.New("TomoX service not found")
 	}
-
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return result, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return result, err
 	}
@@ -2088,7 +2094,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBidTree(ctx context.Context, baseToke
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2108,7 +2118,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetPrice(ctx context.Context, baseToken,
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2128,7 +2142,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLastEpochPrice(ctx context.Context, b
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2148,7 +2166,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetCurrentEpochPrice(ctx context.Context
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2168,7 +2190,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetAskTree(ctx context.Context, baseToke
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2188,7 +2214,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetOrderById(ctx context.Context, baseTo
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2209,7 +2239,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetTradingOrderBookInfo(ctx context.Cont
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2229,7 +2263,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLiquidationPriceTree(ctx context.Cont
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2249,7 +2287,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetInvestingTree(ctx context.Context, le
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2269,7 +2311,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBorrowingTree(ctx context.Context, le
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2289,7 +2335,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLendingOrderBookInfo(tx context.Conte
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2309,7 +2359,11 @@ func (s *PublicTomoXTransactionPoolAPI) getLendingOrderTree(ctx context.Context,
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2329,7 +2383,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLendingTradeTree(ctx context.Context,
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2349,7 +2407,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLiquidationTimeTree(ctx context.Conte
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2369,7 +2431,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLendingOrderCount(ctx context.Context
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2387,7 +2453,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBestInvesting(ctx context.Context, le
 	if lendingService == nil {
 		return result, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return result, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return result, err
 	}
@@ -2405,7 +2475,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBestBorrowing(ctx context.Context, le
 	if lendingService == nil {
 		return result, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return result, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return result, err
 	}
@@ -2422,7 +2496,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBids(ctx context.Context, baseToken, 
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2442,7 +2520,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetAsks(ctx context.Context, baseToken, 
 	if tomoxService == nil {
 		return nil, errors.New("TomoX service not found")
 	}
-	tomoxState, err := tomoxService.GetTradingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	tomoxState, err := tomoxService.GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2462,7 +2544,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetInvests(ctx context.Context, lendingT
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2482,7 +2568,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetBorrows(ctx context.Context, lendingT
 	if lendingService == nil {
 		return nil, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return nil, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -2536,7 +2626,11 @@ func (s *PublicTomoXTransactionPoolAPI) GetLendingOrderById(ctx context.Context,
 	if lendingService == nil {
 		return lendingItem, errors.New("TomoX Lending service not found")
 	}
-	lendingState, err := lendingService.GetLendingState(block)
+	author, err := s.b.GetEngine().Author(block.Header())
+	if err != nil {
+		return lendingItem, err
+	}
+	lendingState, err := lendingService.GetLendingState(block, author)
 	if err != nil {
 		return lendingItem, err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -454,17 +454,18 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	if err != nil {
 		return err
 	}
+	author, _ := self.chain.Engine().Author(parent.Header())
 	var tomoxState *tradingstate.TradingStateDB
 	var lendingState *lendingstate.LendingStateDB
 	if self.config.Posv != nil {
 		tomoX := self.eth.GetTomoX()
-		tomoxState, err = tomoX.GetTradingState(parent)
+		tomoxState, err = tomoX.GetTradingState(parent, author)
 		if err != nil {
 			log.Error("Failed to get tomox state ", "number", parent.Number(), "err", err)
 			return err
 		}
 		lending := self.eth.GetTomoXLending()
-		lendingState, err = lending.GetLendingState(parent)
+		lendingState, err = lending.GetLendingState(parent, author)
 		if err != nil {
 			log.Error("Failed to get lending state ", "number", parent.Number(), "err", err)
 			return err

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -535,8 +535,8 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tradingstate.OrderItem, tx
 	return nil
 }
 
-func (tomox *TomoX) GetTradingState(block *types.Block) (*tradingstate.TradingStateDB, error) {
-	root, err := tomox.GetTradingStateRoot(block)
+func (tomox *TomoX) GetTradingState(block *types.Block, author common.Address) (*tradingstate.TradingStateDB, error) {
+	root, err := tomox.GetTradingStateRoot(block, author)
 	if err != nil {
 		return nil, err
 	}
@@ -549,8 +549,8 @@ func (tomox *TomoX) GetTradingState(block *types.Block) (*tradingstate.TradingSt
 func (tomox *TomoX) GetStateCache() tradingstate.Database {
 	return tomox.StateCache
 }
-func (tomox *TomoX) HasTradingState(block *types.Block) bool {
-	root, err := tomox.GetTradingStateRoot(block)
+func (tomox *TomoX) HasTradingState(block *types.Block, author common.Address) bool {
+	root, err := tomox.GetTradingStateRoot(block, author)
 	if err != nil {
 		return false
 	}
@@ -564,9 +564,10 @@ func (tomox *TomoX) GetTriegc() *prque.Prque {
 	return tomox.Triegc
 }
 
-func (tomox *TomoX) GetTradingStateRoot(block *types.Block) (common.Hash, error) {
+func (tomox *TomoX) GetTradingStateRoot(block *types.Block, author common.Address) (common.Hash, error) {
 	for _, tx := range block.Transactions() {
-		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr {
+		from := *(tx.From())
+		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr && from.String() == author.String() {
 			if len(tx.Data()) >= 32 {
 				return common.BytesToHash(tx.Data()[:32]), nil
 			}


### PR DESCRIPTION
**Changes in this PR:**
To void arbitrary tx send to following special addresses
```
	TomoXAddr                         = "0x0000000000000000000000000000000000000091"
	TradingStateAddr                  = "0x0000000000000000000000000000000000000092"
	TomoXLendingAddress               = "0x0000000000000000000000000000000000000093"
	TomoXLendingFinalizedTradeAddress = "0x0000000000000000000000000000000000000094"
	LendingLockAddress                = "0x0000000000000000000000000000000000000011"
```
- If txMatch fail to parse, TomoX skip this tx, not raise a bad block
- Adding `0x0000000000000000000000000000000000000011` to black-list
- Validate author of tradingStateRoot tx (tx send to 0x0000000000000000000000000000000000000092) 