### PR TITLE
Update tradeFee to mongodb

### DIFF
--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -362,16 +362,8 @@ func (tomox *TomoX) SyncDataToSDKNode(takerOrderInTx *tradingstate.OrderItem, tx
 		tradeRecord.TakerExchange = updatedTakerOrder.ExchangeAddress
 		tradeRecord.MakerExchange = common.HexToAddress(trade[tradingstate.TradeMakerExchange])
 
-		// feeAmount: all fees are calculated in quoteToken
-		quoteTokenQuantity := big.NewInt(0).Mul(quantity, price)
-		quoteTokenQuantity = big.NewInt(0).Div(quoteTokenQuantity, common.BasePrice)
-		takerFee := big.NewInt(0).Mul(quoteTokenQuantity, tradingstate.GetExRelayerFee(updatedTakerOrder.ExchangeAddress, statedb))
-		takerFee = big.NewInt(0).Div(takerFee, common.TomoXBaseFee)
-		tradeRecord.TakeFee = takerFee
-
-		makerFee := big.NewInt(0).Mul(quoteTokenQuantity, tradingstate.GetExRelayerFee(common.HexToAddress(trade[tradingstate.TradeMakerExchange]), statedb))
-		makerFee = big.NewInt(0).Div(makerFee, common.TomoXBaseFee)
-		tradeRecord.MakeFee = makerFee
+		tradeRecord.MakeFee, _ = new(big.Int).SetString(trade[tradingstate.MakerFee], 10)
+		tradeRecord.TakeFee, _ = new(big.Int).SetString(trade[tradingstate.TakerFee], 10)
 
 		// set makerOrderType, takerOrderType
 		tradeRecord.MakerOrderType = trade[tradingstate.MakerOrderType]

--- a/tomox/tradingstate/trade.go
+++ b/tomox/tradingstate/trade.go
@@ -22,6 +22,8 @@ const (
 	TradeQuoteToken     = "qToken"
 	TradePrice          = "tradedPrice"
 	MakerOrderType      = "makerOrderType"
+	MakerFee            = "makerFee"
+	TakerFee            = "takerFee"
 )
 
 type Trade struct {


### PR DESCRIPTION
fix #284 
In previous versions, SDK nodes re-calculate makerFee, takerFee then inserting to mongodb
A mistake in this process causes wrong makerFee, takerFee in some of the trading pairs

**Changes in this PR:** 
- collect tradeFee directly from core matching engine

**Guide to update mongodb of TOMODEX**
- Update script of SDK node, exporting to new database name `--tomox.dbengine "mongodb"  --tomox.dbName "YOUR_NEW_DATABASE_NAME"`, start a new SDK node
- Start a new SDK node, starting from block TomoX hard fork: **20581700** or any block earlier than this block
- After SDK node catch up the latest block, switch your TOMODEX database to `YOUR_NEW_DATABASE_NAME`
- Now you can stop the old SDK node and drop the old database safely