### PR TITLE
Update txMatchTime

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2565,12 +2565,8 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 			if ok && rejected != nil {
 				rejectedOrders = rejected.([]*tradingstate.OrderItem)
 			}
-
-			// the smallest time unit in mongodb is millisecond
-			// hence, we should update time in millisecond
-			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
-			milliSecond := txMatchBatch.Timestamp / 1e6
-			txMatchTime := time.Unix(0, milliSecond*1e6).UTC()
+			
+			txMatchTime := time.Unix(block.Header().Time.Int64(), 0).UTC()
 			if err := tomoXService.SyncDataToSDKNode(takerOrderInTx, txMatchBatch.TxHash, txMatchTime, currentState, trades, rejectedOrders, &dirtyOrderCount); err != nil {
 				log.Crit("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2658,11 +2658,7 @@ func (bc *BlockChain) logLendingData(block *types.Block) {
 				rejectedOrders = rejected.([]*lendingstate.LendingItem)
 			}
 
-			// the smallest time unit in mongodb is millisecond
-			// hence, we should update time in millisecond
-			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
-			milliSecond := batch.Timestamp / 1e6
-			txMatchTime := time.Unix(0, milliSecond*1e6).UTC()
+			txMatchTime := time.Unix(block.Header().Time.Int64(), 0).UTC()
 			statedb, _ := bc.State()
 
 			if err := lendingService.SyncDataToSDKNode(bc, statedb.Copy(),  block, item, batch.TxHash, txMatchTime, trades, rejectedOrders, &dirtyOrderCount); err != nil {

--- a/tomoxlending/tomoxlending.go
+++ b/tomoxlending/tomoxlending.go
@@ -481,7 +481,7 @@ func (l *Lending) UpdateLiquidatedTrade(blockTime uint64, result lendingstate.Fi
 	db.InitLendingBulk()
 
 	txhash := result.TxHash
-	txTime := time.Unix(0, (result.Timestamp/1e6)*1e6).UTC() // round to milliseconds
+	txTime := time.Unix(int64(blockTime), 0).UTC()
 	if err := l.UpdateLendingTrade(trades, txhash, txTime); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:**

In preliminary designs of tomox, txMatch is added to txpool as normal tx -> multiple txs can stay in txpool. We added timestamp to txMatch to sort txMatches by time. Then, tomox-sdk-full also used that timestamp to update order.UpdatedAt in mongodb

We DONOT verify txMatch.Timestamp https://github.com/tomochain/tomochain/blob/7063abddfd0737180f59c5b758b9899023723dad/miner/worker.go#L688
It may be invalid

For example:

This order was created at tx https://scan.tomochain.com/api/orders/0x223b33b0165f38472c69f45016f5a9cea3a389338893bc76e4c5b0f60690301a

While order.UpdatedAt = 2020-06-29T16:15:12.869Z

 the above txTimetamp is 2020-06-29T16:15:14.000Z
https://scan.tomochain.com/api/txs/0xf898371d37e765bf02027782d6dd8d787f0a74cebe828f170e9e4f3b0eb22393




**Solution:**
It's safe and correct to use block.Header().Time updating order.UpdatedAt in mongodb because:
- Block has at most 1 txMatch / txLending
- BlockTime has been verified by the consensus, no one can tamper