### PR TITLE
Update rpc apis

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -484,3 +484,11 @@ func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Bloc
 	}
 	return dirty, nil
 }
+
+func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
+	chainID := new(big.Int)
+	if config := api.e.chainConfig; config.IsEIP155(api.e.blockchain.CurrentBlock().Number()) {
+		chainID = config.ChainId
+	}
+	return (hexutil.Uint64)(chainID.Uint64())
+}

--- a/eth/api.go
+++ b/eth/api.go
@@ -492,3 +492,12 @@ func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 	}
 	return (hexutil.Uint64)(chainID.Uint64())
 }
+
+// GetOwner return masternode owner of the given coinbase address
+func (api *PublicEthereumAPI) GetOwnerByCoinbase(ctx context.Context, coinbase common.Address, blockNr rpc.BlockNumber) (common.Address,  error) {
+	statedb, _, err := api.e.ApiBackend.StateAndHeaderByNumber(ctx, blockNr)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return statedb.GetOwner(coinbase), nil
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -264,12 +264,12 @@ func (b *EthApiBackend) GetEngine() consensus.Engine {
 	return b.eth.engine
 }
 
-func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{} {
+func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	header := s.eth.blockchain.GetHeaderByHash(hash)
 	if header != nil {
 		data, err := ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
 		if err == nil {
-			rewards := make(map[string]interface{})
+			rewards := make(map[string]map[string]map[string]*big.Int)
 			err = json.Unmarshal(data, &rewards)
 			if err == nil {
 				return rewards
@@ -277,7 +277,7 @@ func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{}
 		} else {
 			data, err = ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
 			if err == nil {
-				rewards := make(map[string]interface{})
+				rewards := make(map[string]map[string]map[string]*big.Int)
 				err = json.Unmarshal(data, &rewards)
 				if err == nil {
 					return rewards
@@ -285,7 +285,7 @@ func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{}
 			}
 		}
 	}
-	return make(map[string]interface{})
+	return make(map[string]map[string]map[string]*big.Int)
 }
 
 // GetVotersRewards return a map of voters of snapshot at given block hash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -510,7 +510,7 @@ func (s *PublicBlockChainAPI) BlockNumber() *big.Int {
 }
 
 // BlockNumber returns the block number of the chain head.
-func (s *PublicBlockChainAPI) GetRewardByHash(hash common.Hash) map[string]interface{} {
+func (s *PublicBlockChainAPI) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	return s.b.GetRewardByHash(hash)
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -84,7 +84,7 @@ type Backend interface {
 	CurrentBlock() *types.Block
 	GetIPCClient() (*ethclient.Client, error)
 	GetEngine() consensus.Engine
-	GetRewardByHash(hash common.Hash) map[string]interface{}
+	GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int
 
 	GetVotersRewards(common.Address) map[common.Address]*big.Int
 	GetVotersCap(checkpoint *big.Int, masterAddr common.Address, voters []common.Address) map[common.Address]*big.Int

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -434,6 +434,11 @@ web3._extend({
 	property: 'eth',
 	methods: [
 		new web3._extend.Method({
+			name: 'chainId',
+			call: 'eth_chainId',
+			params: 0
+		}),
+		new web3._extend.Method({
 			name: 'sign',
 			call: 'eth_sign',
 			params: 2,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -480,6 +480,12 @@ web3._extend({
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.utils.toHex]
 		}),
+		new web3._extend.Method({
+			name: 'GetOwnerByCoinbase',
+			call: 'eth_getOwnerByCoinbase',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -220,12 +220,12 @@ func (b *LesApiBackend) GetIPCClient() (*ethclient.Client, error) {
 func (b *LesApiBackend) GetEngine() consensus.Engine {
 	return b.eth.engine
 }
-func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{} {
+func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	header := s.eth.blockchain.GetHeaderByHash(hash)
 	if header != nil {
 		data, err := ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
 		if err == nil {
-			rewards := make(map[string]interface{})
+			rewards := make(map[string]map[string]map[string]*big.Int)
 			err = json.Unmarshal(data, &rewards)
 			if err == nil {
 				return rewards
@@ -233,7 +233,7 @@ func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{}
 		} else {
 			data, err = ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
 			if err == nil {
-				rewards := make(map[string]interface{})
+				rewards := make(map[string]map[string]map[string]*big.Int)
 				err = json.Unmarshal(data, &rewards)
 				if err == nil {
 					return rewards
@@ -241,7 +241,7 @@ func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]interface{}
 			}
 		}
 	}
-	return make(map[string]interface{})
+	return make(map[string]map[string]map[string]*big.Int)
 }
 
 // GetVotersRewards return a map of voters of snapshot at given block hash

--- a/params/config.go
+++ b/params/config.go
@@ -109,7 +109,7 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllPosvProtocolChanges   = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &PosvConfig{Period: 0, Epoch: 30000}}
+	AllPosvProtocolChanges   = &ChainConfig{big.NewInt(89), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &PosvConfig{Period: 0, Epoch: 30000}}
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 	TestChainConfig          = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
 	TestRules                = TestChainConfig.Rules(new(big.Int))


### PR DESCRIPTION
Changes in this PR: 
- Cherry pick b848ab6 : add **eth_chainId**
- Add **eth_getOwnerByCoinbase** 
https://github.com/tomochain/tomochain-rosetta-gateway need to know masternode owner for tracking beneficiary of tx fee
- Update **eth_getRewardByHash** (fix https://github.com/tomochain/tomochain-rosetta-gateway/issues/6) 
 return `map[string]map[string]map[string]*big.Int` instead of `map[string]interface{}`
  Reason: for `interface{}` , json.Unmarshal automatically convert number to uint/int . Mathematics operations on uint/int is incorrect with big number
