### PR TITLE
Fix validation of trc21 tx

### DIFF
--- a/core/state/trc21_reader.go
+++ b/core/state/trc21_reader.go
@@ -2,9 +2,10 @@ package state
 
 import (
 	"bytes"
-	"github.com/hashicorp/golang-lru"
-	"github.com/tomochain/tomochain/common"
 	"math/big"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/tomochain/tomochain/common"
 )
 
 var (
@@ -131,7 +132,8 @@ func ValidateTRC21Tx(statedb *StateDB, from common.Address, token common.Address
 	} else {
 		// we both accept tx with balance = 0 and fee = 0
 		minFeeTokenKey := GetLocSimpleVariable(SlotTRC21Token["minFee"])
-		if !common.EmptyHash(minFeeTokenKey) {
+		minFeeHash := statedb.GetState(token, minFeeTokenKey)
+		if common.EmptyHash(minFeeHash) {
 			return true
 		}
 	}


### PR DESCRIPTION
ValidateTRC21Tx is not validate correctly as its comment 'we both accept tx with balance = 0 and fee = 0'.
The current checking only get the key and check if that key is zero or not. With this checking, it allows any value of `minFee` to pass this validation. So, to make it correct we need to check if the `statedb` at that key instead.