### PR TITLE
Cleanup chain config and unify how to check fork blocks

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tomochain/tomochain/consensus"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"math/big"
 	"sync"
 	"time"
@@ -30,9 +28,11 @@ import (
 	"github.com/tomochain/tomochain/accounts/abi/bind"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/math"
+	"github.com/tomochain/tomochain/consensus"
 	"github.com/tomochain/tomochain/consensus/ethash"
 	"github.com/tomochain/tomochain/core"
 	"github.com/tomochain/tomochain/core/bloombits"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/state"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/core/vm"
@@ -202,7 +202,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call tomochain.Call
 	return rval, err
 }
 
-//FIXME: please use copyState for this function
+// FIXME: please use copyState for this function
 // CallContractWithState executes a contract call at the given state.
 func (b *SimulatedBackend) CallContractWithState(call tomochain.CallMsg, chain consensus.ChainContext, statedb *state.StateDB) ([]byte, error) {
 	// Ensure message is initialized properly.
@@ -285,7 +285,6 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call tomochain.CallM
 
 		snapshot := b.pendingState.Snapshot()
 		_, _, failed, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
-		fmt.Println("EstimateGas",err,failed)
 		b.pendingState.RevertToSnapshot(snapshot)
 
 		if err != nil || failed {

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -51,11 +51,12 @@ func (w *wizard) makeGenesis() {
 		Difficulty: big.NewInt(524288),
 		Alloc:      make(core.GenesisAlloc),
 		Config: &params.ChainConfig{
-			HomesteadBlock: big.NewInt(1),
-			EIP150Block:    big.NewInt(2),
-			EIP155Block:    big.NewInt(3),
-			EIP158Block:    big.NewInt(3),
-			ByzantiumBlock: big.NewInt(4),
+			TIPSigningBlock: big.NewInt(0),
+			HomesteadBlock:  big.NewInt(1),
+			EIP150Block:     big.NewInt(2),
+			EIP155Block:     big.NewInt(3),
+			EIP158Block:     big.NewInt(3),
+			ByzantiumBlock:  big.NewInt(4),
 		},
 	}
 	// Figure out which consensus engine to choose
@@ -385,6 +386,10 @@ func (w *wizard) manageGenesis() {
 		fmt.Println()
 		fmt.Printf("Which block should Byzantium come into effect? (default = %v)\n", w.conf.Genesis.Config.ByzantiumBlock)
 		w.conf.Genesis.Config.ByzantiumBlock = w.readDefaultBigInt(w.conf.Genesis.Config.ByzantiumBlock)
+
+		fmt.Println()
+		fmt.Printf("Which block should TIP signing come into effect? (default = %v)\n", w.conf.Genesis.Config.TIPSigningBlock)
+		w.conf.Genesis.Config.TIPSigningBlock = w.readDefaultBigInt(w.conf.Genesis.Config.TIPSigningBlock)
 
 		out, _ := json.MarshalIndent(w.conf.Genesis.Config, "", "  ")
 		fmt.Printf("Chain configuration updated:\n\n%s\n", out)

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -51,12 +51,13 @@ func (w *wizard) makeGenesis() {
 		Difficulty: big.NewInt(524288),
 		Alloc:      make(core.GenesisAlloc),
 		Config: &params.ChainConfig{
-			TIPSigningBlock: big.NewInt(0),
-			HomesteadBlock:  big.NewInt(1),
-			EIP150Block:     big.NewInt(2),
-			EIP155Block:     big.NewInt(3),
-			EIP158Block:     big.NewInt(3),
-			ByzantiumBlock:  big.NewInt(4),
+			TIPSigningBlock:              big.NewInt(0),
+			HomesteadBlock:               big.NewInt(1),
+			EIP150Block:                  big.NewInt(2),
+			EIP155Block:                  big.NewInt(3),
+			EIP158Block:                  big.NewInt(3),
+			ByzantiumBlock:               big.NewInt(4),
+			TIPTomoXCancellationFeeBlock: big.NewInt(4),
 		},
 	}
 	// Figure out which consensus engine to choose
@@ -390,6 +391,10 @@ func (w *wizard) manageGenesis() {
 		fmt.Println()
 		fmt.Printf("Which block should TIP signing come into effect? (default = %v)\n", w.conf.Genesis.Config.TIPSigningBlock)
 		w.conf.Genesis.Config.TIPSigningBlock = w.readDefaultBigInt(w.conf.Genesis.Config.TIPSigningBlock)
+
+		fmt.Println()
+		fmt.Printf("Which block should TIP TomoX cancellation fee come into effect? (default = %v)\n", w.conf.Genesis.Config.TIPTomoXCancellationFeeBlock)
+		w.conf.Genesis.Config.TIPTomoXCancellationFeeBlock = w.readDefaultBigInt(w.conf.Genesis.Config.TIPTomoXCancellationFeeBlock)
 
 		out, _ := json.MarshalIndent(w.conf.Genesis.Config, "", "  ")
 		fmt.Printf("Chain configuration updated:\n\n%s\n", out)

--- a/cmd/tomo/chaincmd.go
+++ b/cmd/tomo/chaincmd.go
@@ -19,12 +19,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"os"
 	"runtime"
 	"strconv"
 	"sync/atomic"
 	"time"
+
+	"github.com/tomochain/tomochain/core/rawdb"
 
 	"github.com/tomochain/tomochain/cmd/utils"
 	"github.com/tomochain/tomochain/common"
@@ -133,7 +134,6 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 			utils.SyncModeFlag,
 			utils.FakePoWFlag,
 			utils.TestnetFlag,
-			utils.RinkebyFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `

--- a/cmd/tomo/chaincmd.go
+++ b/cmd/tomo/chaincmd.go
@@ -25,12 +25,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tomochain/tomochain/core/rawdb"
-
 	"github.com/tomochain/tomochain/cmd/utils"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/console"
 	"github.com/tomochain/tomochain/core"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/state"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/eth/downloader"

--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/naoina/toml"
 	"gopkg.in/urfave/cli.v1"
 
-	"github.com/naoina/toml"
 	"github.com/tomochain/tomochain/cmd/utils"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/eth"

--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -20,13 +20,14 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"gopkg.in/urfave/cli.v1"
 	"io"
 	"math/big"
 	"os"
 	"reflect"
 	"strings"
 	"unicode"
+
+	"gopkg.in/urfave/cli.v1"
 
 	"github.com/naoina/toml"
 	"github.com/tomochain/tomochain/cmd/utils"
@@ -159,11 +160,6 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 		common.TRC21IssuerSMC = common.TRC21IssuerSMCTestNet
 		cfg.Eth.NetworkId = 89
 		common.RelayerRegistrationSMC = common.RelayerRegistrationSMCTestnet
-		common.TIPTRC21Fee = common.TIPTomoXTestnet
-		common.TIPSigning = big.NewInt(0)
-		common.TIPRandomize = big.NewInt(0)
-		common.TIP2019Block = big.NewInt(0)
-		common.BlackListHFNumber = uint64(0)
 	}
 
 	// Rewound

--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -157,7 +157,6 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 	// Check testnet is enable.
 	if ctx.GlobalBool(utils.TomoTestnetFlag.Name) {
 		common.IsTestnet = true
-		common.TRC21IssuerSMC = common.TRC21IssuerSMCTestNet
 		cfg.Eth.NetworkId = 89
 		common.RelayerRegistrationSMC = common.RelayerRegistrationSMCTestnet
 	}

--- a/cmd/tomo/consolecmd.go
+++ b/cmd/tomo/consolecmd.go
@@ -124,8 +124,6 @@ func remoteConsole(ctx *cli.Context) error {
 		if path != "" {
 			if ctx.GlobalBool(utils.TestnetFlag.Name) {
 				path = filepath.Join(path, "testnet")
-			} else if ctx.GlobalBool(utils.RinkebyFlag.Name) {
-				path = filepath.Join(path, "rinkeby")
 			}
 		}
 		endpoint = fmt.Sprintf("%s/tomo.ipc", path)

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -110,7 +110,6 @@ var (
 		//utils.DeveloperFlag,
 		//utils.DeveloperPeriodFlag,
 		//utils.TestnetFlag,
-		//utils.RinkebyFlag,
 		//utils.VMEnableDebugFlag,
 		utils.TomoTestnetFlag,
 		utils.RewoundFlag,

--- a/cmd/tomo/usage.go
+++ b/cmd/tomo/usage.go
@@ -71,7 +71,6 @@ var AppHelpFlagGroups = []flagGroup{
 			//utils.NoUSBFlag,
 			utils.NetworkIdFlag,
 			//utils.TestnetFlag,
-			//utils.RinkebyFlag,
 			utils.SyncModeFlag,
 			utils.GCModeFlag,
 			utils.EthStatsURLFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,10 +150,6 @@ var (
 		Name:  "tomo-testnet",
 		Usage: "Tomo test network",
 	}
-	RinkebyFlag = cli.BoolFlag{
-		Name:  "rinkeby",
-		Usage: "Rinkeby network: pre-configured proof-of-authority test network",
-	}
 	DeveloperFlag = cli.BoolFlag{
 		Name:  "dev",
 		Usage: "Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled",
@@ -570,9 +566,6 @@ func MakeDataDir(ctx *cli.Context) string {
 		if ctx.GlobalBool(TestnetFlag.Name) {
 			return filepath.Join(path, "testnet")
 		}
-		if ctx.GlobalBool(RinkebyFlag.Name) {
-			return filepath.Join(path, "rinkeby")
-		}
 		return path
 	}
 	Fatalf("Cannot determine default data directory, please set manually (--datadir)")
@@ -625,8 +618,6 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		}
 	// case ctx.GlobalBool(TestnetFlag.Name):
 	// 	urls = params.TestnetBootnodes
-	// case ctx.GlobalBool(RinkebyFlag.Name):
-	// 	urls = params.RinkebyBootnodes
 	case cfg.BootstrapNodes != nil:
 		return // already set, don't apply defaults.
 	case !ctx.GlobalIsSet(BootnodesFlag.Name):
@@ -656,8 +647,6 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 		} else {
 			urls = strings.Split(ctx.GlobalString(BootnodesFlag.Name), ",")
 		}
-	case ctx.GlobalBool(RinkebyFlag.Name):
-		urls = params.RinkebyBootnodes
 	case cfg.BootstrapNodesV5 != nil:
 		return // already set, don't apply defaults.
 	}
@@ -915,8 +904,6 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 		cfg.DataDir = "" // unless explicitly requested, use memory databases
 	case ctx.GlobalBool(TestnetFlag.Name):
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "testnet")
-	case ctx.GlobalBool(RinkebyFlag.Name):
-		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "rinkeby")
 	}
 
 	if ctx.GlobalIsSet(KeyStoreDirFlag.Name) {
@@ -1083,7 +1070,6 @@ func SetTomoXConfig(ctx *cli.Context, cfg *tomox.Config, tomoDataDir string) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	// Avoid conflicting network flags
-	checkExclusive(ctx, DeveloperFlag, TestnetFlag, RinkebyFlag)
 	checkExclusive(ctx, FastSyncFlag, LightModeFlag, SyncModeFlag)
 	checkExclusive(ctx, LightServFlag, LightModeFlag)
 	checkExclusive(ctx, LightServFlag, SyncModeFlag, "light")
@@ -1154,11 +1140,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 			cfg.NetworkId = 3
 		}
 		cfg.Genesis = core.DefaultTestnetGenesisBlock()
-	case ctx.GlobalBool(RinkebyFlag.Name):
-		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
-			cfg.NetworkId = 4
-		}
-		cfg.Genesis = core.DefaultRinkebyGenesisBlock()
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		// Create new developer account or reuse existing one
 		var (
@@ -1214,8 +1195,6 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	switch {
 	case ctx.GlobalBool(TestnetFlag.Name):
 		genesis = core.DefaultTestnetGenesisBlock()
-	case ctx.GlobalBool(RinkebyFlag.Name):
-		genesis = core.DefaultRinkebyGenesisBlock()
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		Fatalf("Developer chains are ephemeral")
 	}

--- a/common/constants.go
+++ b/common/constants.go
@@ -49,7 +49,6 @@ var (
 	RelayerRegistrationSMCTestnet = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
 	LendingRegistrationSMC        = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
 	LendingRegistrationSMCTestnet = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
-	TRC21IssuerSMCTestNet         = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
 	TRC21IssuerSMC                = HexToAddress("0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee")
 	TomoXListingSMC               = HexToAddress("0xDE34dD0f536170993E8CFF639DdFfCF1A85D3E53")
 	TomoXListingSMCTestNet        = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")

--- a/common/constants.go
+++ b/common/constants.go
@@ -21,50 +21,45 @@ const (
 	DefaultMinGasPrice         = 250000000
 	MergeSignRange             = 15
 	RangeReturnSigner          = 150
-	MinimunMinerBlockPerEpoch  = 1
+	MinimumMinerBlockPerEpoch  = 1
 	IgnoreSignerCheckBlock     = uint64(14458500)
 	OneYear                    = uint64(365 * 86400)
 	LiquidateLendingTradeBlock = uint64(100)
+	LimitTimeFinality          = uint64(30) // limit in 30 block
 )
 
-var Rewound = uint64(0)
+var (
+	StoreRewardFolder string
+	RollbackHash      Hash
 
-// hardforks
-var TIP2019Block = big.NewInt(1050000)
-var TIPSigning = big.NewInt(3000000)
-var TIPRandomize = big.NewInt(3464000)
-var BlackListHFNumber = uint64(9349100)
-var TIPTomoX = big.NewInt(20581700)
-var TIPTomoXLending = big.NewInt(21430200)
-var TIPTomoXCancellationFee = big.NewInt(30915660)
-var TIPTomoXTestnet = big.NewInt(0)
-var IsTestnet bool = false
-var StoreRewardFolder string
-var RollbackHash Hash
-var BasePrice = big.NewInt(1000000000000000000)                         // 1
-var RelayerLockedFund = big.NewInt(20000)                               // 20000 TOMO
-var RelayerFee = big.NewInt(1000000000000000)                           // 0.001
-var TomoXBaseFee = big.NewInt(10000)                                    // 1 / TomoXBaseFee
-var RelayerCancelFee = big.NewInt(100000000000000)                      // 0.0001
-var TomoXBaseCancelFee = new(big.Int).Mul(TomoXBaseFee, big.NewInt(10)) // 1/ (TomoXBaseFee *10)
-var RelayerLendingFee = big.NewInt(10000000000000000)                   // 0.01
-var RelayerLendingCancelFee = big.NewInt(1000000000000000)              // 0.001
-var BaseLendingInterest = big.NewInt(100000000)                         // 1e8
+	Rewound        = uint64(0)
+	IsTestnet bool = false
 
-var MinGasPrice = big.NewInt(DefaultMinGasPrice)
-var RelayerRegistrationSMC = "0x16c63b79f9C8784168103C0b74E6A59EC2de4a02"
-var RelayerRegistrationSMCTestnet = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
-var LendingRegistrationSMC = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
-var LendingRegistrationSMCTestnet = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
-var TRC21IssuerSMCTestNet = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
-var TRC21IssuerSMC = HexToAddress("0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee")
-var TomoXListingSMC = HexToAddress("0xDE34dD0f536170993E8CFF639DdFfCF1A85D3E53")
-var TomoXListingSMCTestNet = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
-var TRC21GasPriceBefore = big.NewInt(2500)
-var TRC21GasPrice = big.NewInt(250000000)
-var RateTopUp = big.NewInt(90) // 90%
-var BaseTopUp = big.NewInt(100)
-var BaseRecall = big.NewInt(100)
+	BasePrice                     = big.NewInt(1000000000000000000)                // 1
+	RelayerLockedFund             = big.NewInt(20000)                              // 20000 TOMO
+	RelayerFee                    = big.NewInt(1000000000000000)                   // 0.001
+	TomoXBaseFee                  = big.NewInt(10000)                              // 1 / TomoXBaseFee
+	RelayerCancelFee              = big.NewInt(100000000000000)                    // 0.0001
+	TomoXBaseCancelFee            = new(big.Int).Mul(TomoXBaseFee, big.NewInt(10)) // 1/ (TomoXBaseFee *10)
+	RelayerLendingFee             = big.NewInt(10000000000000000)                  // 0.01
+	RelayerLendingCancelFee       = big.NewInt(1000000000000000)                   // 0.001
+	BaseLendingInterest           = big.NewInt(100000000)                          // 1e8
+	MinGasPrice                   = big.NewInt(DefaultMinGasPrice)
+	RelayerRegistrationSMC        = "0x16c63b79f9C8784168103C0b74E6A59EC2de4a02"
+	RelayerRegistrationSMCTestnet = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
+	LendingRegistrationSMC        = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
+	LendingRegistrationSMCTestnet = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
+	TRC21IssuerSMCTestNet         = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
+	TRC21IssuerSMC                = HexToAddress("0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee")
+	TomoXListingSMC               = HexToAddress("0xDE34dD0f536170993E8CFF639DdFfCF1A85D3E53")
+	TomoXListingSMCTestNet        = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
+	TRC21GasPriceBefore           = big.NewInt(2500)
+	TRC21GasPrice                 = big.NewInt(250000000)
+	RateTopUp                     = big.NewInt(90) // 90%
+	BaseTopUp                     = big.NewInt(100)
+	BaseRecall                    = big.NewInt(100)
+)
+
 var Blacklist = map[Address]bool{
 	HexToAddress("0x5248bfb72fd4f234e062d3e9bb76f08643004fcd"): true,
 	HexToAddress("0x5ac26105b35ea8935be382863a70281ec7a985e9"): true,
@@ -128,5 +123,3 @@ var Blacklist = map[Address]bool{
 	HexToAddress("0xe187cf86c2274b1f16e8225a7da9a75aba4f1f5f"): true,
 	HexToAddress("0x0000000000000000000000000000000000000011"): true,
 }
-var TIPTRC21Fee = big.NewInt(13523400)
-var LimitTimeFinality = uint64(30) // limit in 30 block

--- a/consensus/posv/api.go
+++ b/consensus/posv/api.go
@@ -16,11 +16,12 @@
 package posv
 
 import (
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/rpc"
-	"math/big"
 )
 
 // API is a user facing RPC API to allow controlling the signer and voting
@@ -106,7 +107,6 @@ func (api *API) NetworkInformation() NetworkInformation {
 		info.LendingAddress = common.HexToAddress(common.LendingRegistrationSMCTestnet)
 		info.RelayerRegistrationAddress = common.HexToAddress(common.RelayerRegistrationSMCTestnet)
 		info.TomoXListingAddress = common.TomoXListingSMCTestNet
-		info.TomoZAddress = common.TRC21IssuerSMCTestNet
 	} else {
 		info.LendingAddress = common.HexToAddress(common.LendingRegistrationSMC)
 		info.RelayerRegistrationAddress = common.HexToAddress(common.RelayerRegistrationSMC)

--- a/consensus/posv/posv_test.go
+++ b/consensus/posv/posv_test.go
@@ -23,8 +23,9 @@ func TestGetM1M2FromCheckpointHeader(t *testing.T) {
 	}
 	epoch := uint64(900)
 	config := &params.ChainConfig{
+		TIPRandomizeBlock: big.NewInt(0),
 		Posv: &params.PosvConfig{
-			Epoch: uint64(epoch),
+			Epoch: epoch,
 		},
 	}
 	testMoveM2 := []uint64{0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0, 1, 1, 1, 2, 2, 2}

--- a/contracts/tests/Inherited_test.go
+++ b/contracts/tests/Inherited_test.go
@@ -2,15 +2,15 @@ package tests
 
 import (
 	"fmt"
-	"github.com/tomochain/tomochain/accounts/abi/bind"
-	"github.com/tomochain/tomochain/accounts/abi/bind/backends"
-	"github.com/tomochain/tomochain/common"
-	"github.com/tomochain/tomochain/core"
-	"github.com/tomochain/tomochain/crypto"
-	"github.com/tomochain/tomochain/log"
 	"math/big"
 	"os"
 	"testing"
+
+	"github.com/tomochain/tomochain/accounts/abi/bind"
+	"github.com/tomochain/tomochain/accounts/abi/bind/backends"
+	"github.com/tomochain/tomochain/core"
+	"github.com/tomochain/tomochain/crypto"
+	"github.com/tomochain/tomochain/log"
 )
 
 var (
@@ -22,7 +22,6 @@ func TestPriceFeed(t *testing.T) {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.LvlTrace)
 	log.Root().SetHandler(glogger)
-	common.TIPTomoXCancellationFee = big.NewInt(0)
 	// init genesis
 	contractBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
 		mainAddr: {Balance: big.NewInt(0).Mul(big.NewInt(10000000000000), big.NewInt(10000000000000))},

--- a/contracts/trc21issuer/simulation/test/main.go
+++ b/contracts/trc21issuer/simulation/test/main.go
@@ -8,14 +8,13 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/tomochain/tomochain/params"
-
 	"github.com/tomochain/tomochain/accounts/abi/bind"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/contracts/trc21issuer"
 	"github.com/tomochain/tomochain/contracts/trc21issuer/simulation"
 	"github.com/tomochain/tomochain/ethclient"
+	"github.com/tomochain/tomochain/params"
 )
 
 var (

--- a/contracts/trc21issuer/simulation/test/main.go
+++ b/contracts/trc21issuer/simulation/test/main.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/tomochain/tomochain/params"
+
 	"github.com/tomochain/tomochain/accounts/abi/bind"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/contracts/trc21issuer"
 	"github.com/tomochain/tomochain/contracts/trc21issuer/simulation"
 	"github.com/tomochain/tomochain/ethclient"
-	"log"
-	"math/big"
-	"time"
 )
 
 var (
@@ -49,7 +52,12 @@ func airDropTokenToAccountNoTomo() {
 		log.Fatal("can't transaction's receipt ", err, "hash", tx.Hash().Hex())
 	}
 	fee := big.NewInt(0).SetUint64(hexutil.MustDecodeUint64(receipt["gasUsed"].(string)))
-	if hexutil.MustDecodeUint64(receipt["blockNumber"].(string)) > common.TIPTRC21Fee.Uint64() {
+	block, ok := new(big.Int).SetString(receipt["blockNumber"].(string), 16)
+	if !ok {
+		log.Fatal("can't convert block number to big.Int")
+		return
+	}
+	if params.TestChainConfig.IsTIPTRC21Fee(block) {
 		fee = fee.Mul(fee, common.TRC21GasPrice)
 	}
 	fmt.Println("fee", fee.Uint64(), "number", hexutil.MustDecodeUint64(receipt["blockNumber"].(string)))
@@ -112,7 +120,12 @@ func testTransferTRC21TokenWithAccountNoTomo() {
 		log.Fatal("can't transaction's receipt ", err, "hash", tx.Hash().Hex())
 	}
 	fee := big.NewInt(0).SetUint64(hexutil.MustDecodeUint64(receipt["gasUsed"].(string)))
-	if hexutil.MustDecodeUint64(receipt["blockNumber"].(string)) > common.TIPTRC21Fee.Uint64() {
+	block, ok := new(big.Int).SetString(receipt["blockNumber"].(string), 16)
+	if !ok {
+		log.Fatal("can't convert block number to big.Int")
+		return
+	}
+	if params.TestChainConfig.IsTIPTRC21Fee(block) {
 		fee = fee.Mul(fee, common.TRC21GasPrice)
 	}
 	fmt.Println("fee", fee.Uint64(), "number", hexutil.MustDecodeUint64(receipt["blockNumber"].(string)))
@@ -179,7 +192,12 @@ func testTransferTrc21Fail() {
 		log.Fatal("can't transaction's receipt ", err, "hash", tx.Hash().Hex())
 	}
 	fee := big.NewInt(0).SetUint64(hexutil.MustDecodeUint64(receipt["gasUsed"].(string)))
-	if hexutil.MustDecodeUint64(receipt["blockNumber"].(string)) > common.TIPTRC21Fee.Uint64() {
+	block, ok := new(big.Int).SetString(receipt["blockNumber"].(string), 16)
+	if !ok {
+		log.Fatal("can't convert block number to big.Int")
+		return
+	}
+	if params.TestChainConfig.IsTIPTRC21Fee(block) {
 		fee = fee.Mul(fee, common.TRC21GasPrice)
 	}
 	fmt.Println("fee", fee.Uint64(), "number", hexutil.MustDecodeUint64(receipt["blockNumber"].(string)))

--- a/contracts/trc21issuer/trc21issuer_test.go
+++ b/contracts/trc21issuer/trc21issuer_test.go
@@ -29,7 +29,6 @@ var (
 )
 
 func TestFeeTxWithTRC21Token(t *testing.T) {
-
 	// init genesis
 	contractBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
 		mainAddr: {Balance: big.NewInt(0).Mul(big.NewInt(10000000000000), big.NewInt(10000000000000))},

--- a/contracts/trc21issuer/trc21issuer_test.go
+++ b/contracts/trc21issuer/trc21issuer_test.go
@@ -1,13 +1,15 @@
 package trc21issuer
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/tomochain/tomochain/accounts/abi/bind"
 	"github.com/tomochain/tomochain/accounts/abi/bind/backends"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/core"
 	"github.com/tomochain/tomochain/crypto"
-	"math/big"
-	"testing"
+	"github.com/tomochain/tomochain/params"
 )
 
 var (
@@ -82,7 +84,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("can't transaction's receipt ", err, "hash", tx.Hash())
 	}
 	fee := big.NewInt(0).SetUint64(receipt.GasUsed)
-	if receipt.Logs[0].BlockNumber > common.TIPTRC21Fee.Uint64() {
+	if params.TestChainConfig.IsTIPTRC21Fee(new(big.Int).SetUint64(receipt.Logs[0].BlockNumber)) {
 		fee = fee.Mul(fee, common.TRC21GasPrice)
 	}
 	remainFee := big.NewInt(0).Sub(minApply, fee)
@@ -134,7 +136,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("can't transaction's receipt ", err, "hash", tx.Hash())
 	}
 	fee = big.NewInt(0).SetUint64(receipt.GasUsed)
-	if receipt.Logs[0].BlockNumber > common.TIPTRC21Fee.Uint64() {
+	if params.TestChainConfig.IsTIPTRC21Fee(new(big.Int).SetUint64(receipt.Logs[0].BlockNumber)) {
 		fee = fee.Mul(fee, common.TRC21GasPrice)
 	}
 	remainFee = big.NewInt(0).Sub(remainFee, fee)

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -418,15 +418,15 @@ func GetCandidatesOwnerBySigner(state *state.StateDB, signerAddr common.Address)
 	return owner
 }
 
-func CalculateRewardForHolders(foundationWalletAddr common.Address, state *state.StateDB, signer common.Address, calcReward *big.Int, blockNumber uint64) (error, map[common.Address]*big.Int) {
-	rewards, err := GetRewardBalancesRate(foundationWalletAddr, state, signer, calcReward, blockNumber)
+func CalculateRewardForHolders(foundationWalletAddr common.Address, state *state.StateDB, signer common.Address, calcReward *big.Int, blockNumber uint64, chainConfig *params.ChainConfig) (error, map[common.Address]*big.Int) {
+	rewards, err := GetRewardBalancesRate(foundationWalletAddr, state, signer, calcReward, blockNumber, chainConfig)
 	if err != nil {
 		return err, nil
 	}
 	return nil, rewards
 }
 
-func GetRewardBalancesRate(foundationWalletAddr common.Address, state *state.StateDB, masterAddr common.Address, totalReward *big.Int, blockNumber uint64) (map[common.Address]*big.Int, error) {
+func GetRewardBalancesRate(foundationWalletAddr common.Address, state *state.StateDB, masterAddr common.Address, totalReward *big.Int, blockNumber uint64, chainConfig *params.ChainConfig) (map[common.Address]*big.Int, error) {
 	owner := GetCandidatesOwnerBySigner(state, masterAddr)
 	balances := make(map[common.Address]*big.Int)
 	rewardMaster := new(big.Int).Mul(totalReward, new(big.Int).SetInt64(common.RewardMasterPercent))
@@ -442,7 +442,7 @@ func GetRewardBalancesRate(foundationWalletAddr common.Address, state *state.Sta
 		// Get voters capacities.
 		voterCaps := make(map[common.Address]*big.Int)
 		for _, voteAddr := range voters {
-			if _, ok := voterCaps[voteAddr]; ok && common.TIP2019Block.Uint64() <= blockNumber {
+			if _, ok := voterCaps[voteAddr]; ok && chainConfig.IsTIP2019(new(big.Int).SetUint64(blockNumber)) {
 				continue
 			}
 			voterCap := stateDatabase.GetVoterCap(state, masterAddr, voteAddr)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1123,10 +1123,11 @@ func TestEIP161AccountRemoval(t *testing.T) {
 		theAddr = common.Address{1}
 		gspec   = &Genesis{
 			Config: &params.ChainConfig{
-				ChainId:        big.NewInt(1),
-				HomesteadBlock: new(big.Int),
-				EIP155Block:    new(big.Int),
-				EIP158Block:    big.NewInt(2),
+				ChainId:         big.NewInt(1),
+				HomesteadBlock:  new(big.Int),
+				EIP155Block:     new(big.Int),
+				EIP158Block:     big.NewInt(2),
+				TIPSigningBlock: big.NewInt(0),
 			},
 			Alloc: GenesisAlloc{address: {Balance: funds}},
 		}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1014,8 +1014,12 @@ func TestEIP155Transition(t *testing.T) {
 		funds      = big.NewInt(1000000000)
 		deleteAddr = common.Address{1}
 		gspec      = &Genesis{
-			Config: &params.ChainConfig{ChainId: big.NewInt(1), EIP155Block: big.NewInt(2), HomesteadBlock: new(big.Int)},
-			Alloc:  GenesisAlloc{address: {Balance: funds}, deleteAddr: {Balance: new(big.Int)}},
+			Config: &params.ChainConfig{
+				ChainId:         big.NewInt(1),
+				TIPSigningBlock: big.NewInt(0),
+				EIP155Block:     big.NewInt(2),
+				HomesteadBlock:  new(big.Int)},
+			Alloc: GenesisAlloc{address: {Balance: funds}, deleteAddr: {Balance: new(big.Int)}},
 		}
 		genesis = gspec.MustCommit(db)
 	)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/tomochain/tomochain/core/rawdb"
-
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
 	"github.com/tomochain/tomochain/consensus/misc"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/state"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/core/vm"

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -108,7 +108,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 	if tokenFeeUsed {
 		fee := new(big.Int).SetUint64(gas)
-		if b.config.IsTIPTRC21Fee(b.header.Number) {
+		if b.config.IsTIPTRC21Fee(new(big.Int).Add(b.header.Number, big.NewInt(1))) {
 			fee = fee.Mul(fee, common.TRC21GasPrice)
 		}
 		state.UpdateTRC21Fee(b.statedb, map[common.Address]*big.Int{*tx.To(): new(big.Int).Sub(feeCapacity[*tx.To()], new(big.Int).SetUint64(gas))}, fee)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -18,8 +18,9 @@ package core
 
 import (
 	"fmt"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"math/big"
+
+	"github.com/tomochain/tomochain/core/rawdb"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
@@ -108,7 +109,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 	if tokenFeeUsed {
 		fee := new(big.Int).SetUint64(gas)
-		if b.header.Number.Cmp(common.TIPTRC21Fee) > 0 {
+		if b.config.IsTIPTRC21Fee(b.header.Number) {
 			fee = fee.Mul(fee, common.TRC21GasPrice)
 		}
 		state.UpdateTRC21Fee(b.statedb, map[common.Address]*big.Int{*tx.To(): new(big.Int).Sub(feeCapacity[*tx.To()], new(big.Int).SetUint64(gas))}, fee)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -108,7 +108,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 	if tokenFeeUsed {
 		fee := new(big.Int).SetUint64(gas)
-		if b.config.IsTIPTRC21Fee(new(big.Int).Add(b.header.Number, big.NewInt(1))) {
+		if b.config.IsTIPTRC21Fee(new(big.Int).Sub(b.header.Number, big.NewInt(1))) {
 			fee = fee.Mul(fee, common.TRC21GasPrice)
 		}
 		state.UpdateTRC21Fee(b.statedb, map[common.Address]*big.Int{*tx.To(): new(big.Int).Sub(feeCapacity[*tx.To()], new(big.Int).SetUint64(gas))}, fee)

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -40,8 +40,11 @@ func ExampleGenerateChain() {
 	)
 	// Ensure that key1 has some funds in the genesis block.
 	gspec := &Genesis{
-		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc:  GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+		Config: &params.ChainConfig{
+			HomesteadBlock:  new(big.Int),
+			TIPSigningBlock: big.NewInt(0),
+		},
+		Alloc: GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
 	}
 	genesis := gspec.MustCommit(db)
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -140,10 +140,10 @@ func (e *GenesisMismatchError) Error() string {
 // SetupGenesisBlock writes or updates the genesis block in db.
 // The block that will be used is:
 //
-//                          genesis == nil       genesis != nil
-//                       +------------------------------------------
-//     db has no genesis |  main-net default  |  genesis
-//     db has genesis    |  from DB           |  genesis (if compatible)
+//	                     genesis == nil       genesis != nil
+//	                  +------------------------------------------
+//	db has no genesis |  main-net default  |  genesis
+//	db has genesis    |  from DB           |  genesis (if compatible)
 //
 // The stored chain configuration will be updated if it is compatible (i.e. does not
 // specify a fork block below the local head block). In case of a conflict, the
@@ -331,18 +331,6 @@ func DefaultTestnetGenesisBlock() *Genesis {
 		GasLimit:   16777216,
 		Difficulty: big.NewInt(1048576),
 		Alloc:      decodePrealloc(testnetAllocData),
-	}
-}
-
-// DefaultRinkebyGenesisBlock returns the Rinkeby network genesis block.
-func DefaultRinkebyGenesisBlock() *Genesis {
-	return &Genesis{
-		Config:     params.RinkebyChainConfig,
-		Timestamp:  1492009146,
-		ExtraData:  hexutil.MustDecode("0x52657370656374206d7920617574686f7269746168207e452e436172746d616e42eb768f2244c8811c63729a21a3569731535f067ffc57839b00206d1ad20c69a1981b489f772031b279182d99e65703f0076e4812653aab85fca0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
-		GasLimit:   4700000,
-		Difficulty: big.NewInt(1),
-		Alloc:      decodePrealloc(rinkebyAllocData),
 	}
 }
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -45,14 +45,20 @@ func TestSetupGenesis(t *testing.T) {
 	var (
 		customghash = common.HexToHash("0xfc8a143549950b0d3e3e7b70b0067b152e6b903ab5438f1ea87f0448ec93da48")
 		customg     = Genesis{
-			Config: &params.ChainConfig{HomesteadBlock: big.NewInt(3)},
+			Config: &params.ChainConfig{
+				HomesteadBlock:  big.NewInt(3),
+				TIPSigningBlock: big.NewInt(0),
+			},
 			Alloc: GenesisAlloc{
 				{1}: {Balance: big.NewInt(1), Storage: map[common.Hash]common.Hash{{1}: {1}}},
 			},
 		}
 		oldcustomg = customg
 	)
-	oldcustomg.Config = &params.ChainConfig{HomesteadBlock: big.NewInt(2)}
+	oldcustomg.Config = &params.ChainConfig{
+		HomesteadBlock:  big.NewInt(2),
+		TIPSigningBlock: big.NewInt(0),
+	}
 	tests := []struct {
 		name       string
 		fn         func(ethdb.Database) (*params.ChainConfig, common.Hash, error)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -24,9 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tomochain/tomochain/log"
-	"github.com/tomochain/tomochain/tomox/tradingstate"
-
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
 	"github.com/tomochain/tomochain/consensus/misc"
@@ -34,7 +31,9 @@ import (
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/core/vm"
 	"github.com/tomochain/tomochain/crypto"
+	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/params"
+	"github.com/tomochain/tomochain/tomox/tradingstate"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -120,7 +120,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 		allLogs = append(allLogs, receipt.Logs...)
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if p.config.IsTIPTRC21Fee(block.Header().Number) {
+			if p.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)
@@ -201,7 +201,7 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 		allLogs = append(allLogs, receipt.Logs...)
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if p.config.IsTIPTRC21Fee(block.Header().Number) {
+			if p.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -120,7 +120,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 		allLogs = append(allLogs, receipt.Logs...)
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if p.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
+			if p.config.IsTIPTRC21Fee(new(big.Int).Sub(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)
@@ -201,7 +201,7 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 		allLogs = append(allLogs, receipt.Logs...)
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if p.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
+			if p.config.IsTIPTRC21Fee(new(big.Int).Sub(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -268,7 +268,7 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 	}
 	st.refundGas()
 
-	if st.evm.ChainConfig().IsTIPTRC21Fee(new(big.Int).Add(st.evm.BlockNumber, big.NewInt(1))) {
+	if st.evm.ChainConfig().IsTIPTRC21Fee(new(big.Int).Sub(st.evm.BlockNumber, big.NewInt(1))) {
 		if (owner != common.Address{}) {
 			st.state.AddBalance(owner, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -268,7 +268,7 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 	}
 	st.refundGas()
 
-	if st.evm.ChainConfig().IsTIPTRC21Fee(st.evm.BlockNumber) {
+	if st.evm.ChainConfig().IsTIPTRC21Fee(new(big.Int).Add(st.evm.BlockNumber, big.NewInt(1))) {
 		if (owner != common.Address{}) {
 			st.state.AddBalance(owner, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -42,8 +42,10 @@ The state transitioning model does all all the necessary work to work out a vali
 3) Create a new state object if the recipient is \0*32
 4) Value transfer
 == If contract creation ==
-  4a) Attempt to run transaction data
-  4b) If valid, use result as code for the new state object
+
+	4a) Attempt to run transaction data
+	4b) If valid, use result as code for the new state object
+
 == end ==
 5) Run Script section
 6) Derive new state root
@@ -266,7 +268,7 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 	}
 	st.refundGas()
 
-	if st.evm.BlockNumber.Cmp(common.TIPTRC21Fee) > 0 {
+	if st.evm.ChainConfig().IsTIPTRC21Fee(st.evm.BlockNumber) {
 		if (owner != common.Address{}) {
 			st.state.AddBalance(owner, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 		}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -24,11 +24,10 @@ import (
 	"math/big"
 	"sync/atomic"
 
-	"github.com/tomochain/tomochain/params"
-
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/crypto"
+	"github.com/tomochain/tomochain/params"
 	"github.com/tomochain/tomochain/rlp"
 )
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -24,6 +24,8 @@ import (
 	"math/big"
 	"sync/atomic"
 
+	"github.com/tomochain/tomochain/params"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/crypto"
@@ -247,7 +249,7 @@ func (tx *Transaction) Size() common.StorageSize {
 // AsMessage requires a signer to derive the sender.
 //
 // XXX Rename message to something less arbitrary?
-func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int) (Message, error) {
+func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int, chainConfig *params.ChainConfig) (Message, error) {
 	msg := Message{
 		nonce:           tx.data.AccountNonce,
 		gasLimit:        tx.data.GasLimit,
@@ -261,7 +263,7 @@ func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int)
 	var err error
 	msg.from, err = Sender(s, tx)
 	if balanceFee != nil {
-		if number.Cmp(common.TIPTRC21Fee) > 0 {
+		if chainConfig.IsTIPTRC21Fee(number) {
 			msg.gasPrice = common.TRC21GasPrice
 		} else {
 			msg.gasPrice = common.TRC21GasPriceBefore

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -262,7 +262,7 @@ func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int,
 	var err error
 	msg.from, err = Sender(s, tx)
 	if balanceFee != nil {
-		if chainConfig.IsTIPTRC21Fee(new(big.Int).Add(number, big.NewInt(1))) {
+		if chainConfig.IsTIPTRC21Fee(new(big.Int).Sub(number, big.NewInt(1))) {
 			msg.gasPrice = common.TRC21GasPrice
 		} else {
 			msg.gasPrice = common.TRC21GasPriceBefore

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -445,9 +445,6 @@ func (tx *Transaction) IsTomoZApplyTransaction() bool {
 	}
 
 	addr := common.TRC21IssuerSMC
-	if common.IsTestnet {
-		addr = common.TRC21IssuerSMCTestNet
-	}
 	if tx.To().String() != addr.String() {
 		return false
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -262,7 +262,7 @@ func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int,
 	var err error
 	msg.from, err = Sender(s, tx)
 	if balanceFee != nil {
-		if chainConfig.IsTIPTRC21Fee(number) {
+		if chainConfig.IsTIPTRC21Fee(new(big.Int).Add(number, big.NewInt(1))) {
 			msg.gasPrice = common.TRC21GasPrice
 		} else {
 			msg.gasPrice = common.TRC21GasPriceBefore

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -25,17 +25,11 @@ import (
 	"math/big"
 	"path/filepath"
 
-	"github.com/tomochain/tomochain/tomox/tradingstate"
-	"github.com/tomochain/tomochain/tomoxlending"
-
-	"github.com/tomochain/tomochain/tomox"
-
-	"github.com/tomochain/tomochain/consensus/posv"
-
 	"github.com/tomochain/tomochain/accounts"
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/math"
 	"github.com/tomochain/tomochain/consensus"
+	"github.com/tomochain/tomochain/consensus/posv"
 	"github.com/tomochain/tomochain/contracts"
 	"github.com/tomochain/tomochain/core"
 	"github.com/tomochain/tomochain/core/bloombits"
@@ -51,6 +45,9 @@ import (
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/params"
 	"github.com/tomochain/tomochain/rpc"
+	"github.com/tomochain/tomochain/tomox"
+	"github.com/tomochain/tomochain/tomox/tradingstate"
+	"github.com/tomochain/tomochain/tomoxlending"
 )
 
 // EthApiBackend implements ethapi.Backend for full nodes

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/tomochain/tomochain/tomox/tradingstate"
-	"github.com/tomochain/tomochain/tomoxlending"
 	"io/ioutil"
 	"math/big"
 	"path/filepath"
+
+	"github.com/tomochain/tomochain/tomox/tradingstate"
+	"github.com/tomochain/tomochain/tomoxlending"
 
 	"github.com/tomochain/tomochain/tomox"
 
@@ -349,7 +350,7 @@ func (b *EthApiBackend) GetVotersRewards(masternodeAddr common.Address) map[comm
 	var voterResults map[common.Address]*big.Int
 	for signer, calcReward := range rewardSigners {
 		if signer == masternodeAddr {
-			err, rewards := contracts.CalculateRewardForHolders(foundationWalletAddr, state, masternodeAddr, calcReward, number)
+			err, rewards := contracts.CalculateRewardForHolders(foundationWalletAddr, state, masternodeAddr, calcReward, number, b.ChainConfig())
 			if err != nil {
 				log.Crit("Fail to calculate reward for holders.", "error", err)
 				return nil

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -701,7 +701,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if api.config.IsTIPTRC21Fee(block.Header().Number) {
+			if api.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			feeCapacity[*tx.To()] = new(big.Int).Sub(feeCapacity[*tx.To()], fee)

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tomochain/tomochain/tomox/tradingstate"
-
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/core"
@@ -40,6 +38,7 @@ import (
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/rlp"
 	"github.com/tomochain/tomochain/rpc"
+	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"github.com/tomochain/tomochain/trie"
 )
 

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -701,7 +701,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if api.config.IsTIPTRC21Fee(new(big.Int).Add(block.Header().Number, big.NewInt(1))) {
+			if api.config.IsTIPTRC21Fee(new(big.Int).Sub(block.Header().Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			feeCapacity[*tx.To()] = new(big.Int).Sub(feeCapacity[*tx.To()], fee)

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"io/ioutil"
 	"math/big"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/tomochain/tomochain/tomox/tradingstate"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
@@ -204,7 +205,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 							balacne = value
 						}
 					}
-					msg, _ := tx.AsMessage(signer, balacne, task.block.Number())
+					msg, _ := tx.AsMessage(signer, balacne, task.block.Number(), api.config)
 					vmctx := core.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
 
 					res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
@@ -444,7 +445,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 						balacne = value
 					}
 				}
-				msg, _ := txs[task.index].AsMessage(signer, balacne, block.Number())
+				msg, _ := txs[task.index].AsMessage(signer, balacne, block.Number(), api.config)
 				vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
@@ -469,7 +470,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			}
 		}
 		// Generate the next state snapshot fast without tracing
-		msg, _ := tx.AsMessage(signer, balacne, block.Number())
+		msg, _ := tx.AsMessage(signer, balacne, block.Number(), api.config)
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})
@@ -567,7 +568,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	}
 	size, _ := database.TrieDB().Size()
 	log.Info("Historical state regenerated", "block", block.NumberU64(), "elapsed", time.Since(start), "size", size)
-	return statedb,tomoxState, nil
+	return statedb, tomoxState, nil
 }
 
 // TraceTransaction returns the structured logs created during the execution of EVM
@@ -669,7 +670,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	}
 	// Recompute transactions up to the target index.
 	feeCapacity := state.GetTRC21FeeCapacityFromState(statedb)
-	if common.TIPSigning.Cmp(block.Header().Number) == 0 {
+	if api.config.TIPSigningBlock.Cmp(block.Header().Number) == 0 {
 		statedb.DeleteAddress(common.HexToAddress(common.BlockSigners))
 	}
 	core.InitSignerInTransactions(api.config, block.Header(), block.Transactions())
@@ -687,7 +688,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 					balanceFee = value
 				}
 			}
-			msg, err := tx.AsMessage(types.MakeSigner(api.config, block.Header().Number), balanceFee, block.Number())
+			msg, err := tx.AsMessage(types.MakeSigner(api.config, block.Header().Number), balanceFee, block.Number(), api.config)
 			if err != nil {
 				return nil, vm.Context{}, nil, fmt.Errorf("tx %x failed: %v", tx.Hash(), err)
 			}
@@ -701,7 +702,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if block.Header().Number.Cmp(common.TIPTRC21Fee) > 0 {
+			if api.config.IsTIPTRC21Fee(block.Header().Number) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			feeCapacity[*tx.To()] = new(big.Int).Sub(feeCapacity[*tx.To()], fee)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -383,7 +383,7 @@ func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendi
 				preMasternodes := c.GetMasternodes(chain, prevHeader)
 				penalties := []common.Address{}
 				for miner, total := range statMiners {
-					if total < common.MinimunMinerBlockPerEpoch {
+					if total < common.MinimumMinerBlockPerEpoch {
 						log.Debug("Find a node not enough requirement create block", "addr", miner.Hex(), "total", total)
 						penalties = append(penalties, miner)
 					}
@@ -536,7 +536,7 @@ func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendi
 				voterResults := make(map[common.Address]interface{})
 				if len(signers) > 0 {
 					for signer, calcReward := range rewardSigners {
-						err, rewards := contracts.CalculateRewardForHolders(foundationWalletAddr, parentState, signer, calcReward, number)
+						err, rewards := contracts.CalculateRewardForHolders(foundationWalletAddr, parentState, signer, calcReward, number, chain.Config())
 						if err != nil {
 							log.Crit("Fail to calculate reward for holders.", "error", err)
 						}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -20,17 +20,18 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"io/ioutil"
 	"math/big"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/common/math"
 	"github.com/tomochain/tomochain/core"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/core/vm"
 	"github.com/tomochain/tomochain/crypto"
@@ -120,7 +121,6 @@ type callTracerTest struct {
 }
 
 func TestPrestateTracerCreate2(t *testing.T) {
-	common.TIPTomoXCancellationFee = big.NewInt(10000000000000)
 	unsignedTx := types.NewTransaction(1, common.HexToAddress("0x00000000000000000000000000000000deadbeef"),
 		new(big.Int), 5000000, big.NewInt(1), []byte{})
 
@@ -176,9 +176,9 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create call tracer: %v", err)
 	}
-	evm := vm.NewEVM(context, statedb, nil, params.MainnetChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	evm := vm.NewEVM(context, statedb, nil, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 
-	msg, err := tx.AsMessage(signer, nil, nil)
+	msg, err := tx.AsMessage(signer, nil, nil, params.TestChainConfig)
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestCallTracer(t *testing.T) {
 			}
 			evm := vm.NewEVM(context, statedb, nil, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
 
-			msg, err := tx.AsMessage(signer, nil, common.Big0)
+			msg, err := tx.AsMessage(signer, nil, common.Big0, params.TestChainConfig)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -926,7 +926,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.config.IsTIPTRC21Fee(env.header.Number) {
+			if env.config.IsTIPTRC21Fee(new(big.Int).Add(env.header.Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)
@@ -1044,7 +1044,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.config.IsTIPTRC21Fee(env.header.Number) {
+			if env.config.IsTIPTRC21Fee(new(big.Int).Add(env.header.Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -619,7 +619,7 @@ func (self *worker) commitNewWork() {
 	if self.config.DAOForkSupport && self.config.DAOForkBlock != nil && self.config.DAOForkBlock.Cmp(header.Number) == 0 {
 		misc.ApplyDAOHardFork(work.state)
 	}
-	if common.TIPSigning.Cmp(header.Number) == 0 {
+	if self.config.TIPSigningBlock.Cmp(header.Number) == 0 {
 		work.state.DeleteAddress(common.HexToAddress(common.BlockSigners))
 	}
 	// won't grasp txs at checkpoint
@@ -839,7 +839,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 	for _, tx := range specialTxs {
 
 		//HF number for black-list
-		if (env.header.Number.Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if env.config.IsBlackListHF(env.header.Number) && !common.IsTestnet {
 			// check if sender is in black list
 			if tx.From() != nil && common.Blacklist[*tx.From()] {
 				log.Debug("Skipping transaction with sender in black-list", "sender", tx.From().Hex())
@@ -926,7 +926,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.header.Number.Cmp(common.TIPTRC21Fee) > 0 {
+			if env.config.IsTIPTRC21Fee(env.header.Number) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)
@@ -952,7 +952,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 
 		//HF number for black-list
-		if (env.header.Number.Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if env.config.IsBlackListHF(env.header.Number) && !common.IsTestnet {
 			// check if sender is in black list
 			if tx.From() != nil && common.Blacklist[*tx.From()] {
 				log.Debug("Skipping transaction with sender in black-list", "sender", tx.From().Hex())
@@ -1044,7 +1044,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.header.Number.Cmp(common.TIPTRC21Fee) > 0 {
+			if env.config.IsTIPTRC21Fee(env.header.Number) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -926,7 +926,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.config.IsTIPTRC21Fee(new(big.Int).Add(env.header.Number, big.NewInt(1))) {
+			if env.config.IsTIPTRC21Fee(new(big.Int).Sub(env.header.Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)
@@ -1044,7 +1044,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 		}
 		if tokenFeeUsed {
 			fee := new(big.Int).SetUint64(gas)
-			if env.config.IsTIPTRC21Fee(new(big.Int).Add(env.header.Number, big.NewInt(1))) {
+			if env.config.IsTIPTRC21Fee(new(big.Int).Sub(env.header.Number, big.NewInt(1))) {
 				fee = fee.Mul(fee, common.TRC21GasPrice)
 			}
 			balanceFee[*tx.To()] = new(big.Int).Sub(balanceFee[*tx.To()], fee)

--- a/mobile/params.go
+++ b/mobile/params.go
@@ -41,15 +41,6 @@ func TestnetGenesis() string {
 	return string(enc)
 }
 
-// RinkebyGenesis returns the JSON spec to use for the Rinkeby test network
-func RinkebyGenesis() string {
-	enc, err := json.Marshal(core.DefaultRinkebyGenesisBlock())
-	if err != nil {
-		panic(err)
-	}
-	return string(enc)
-}
-
 // FoundationBootnodes returns the enode URLs of the P2P bootstrap nodes operated
 // by the foundation running the V5 discovery protocol.
 func FoundationBootnodes() *Enodes {

--- a/params/config.go
+++ b/params/config.go
@@ -358,6 +358,27 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.ConstantinopleBlock, newcfg.ConstantinopleBlock, head) {
 		return newCompatError("Constantinople fork block", c.ConstantinopleBlock, newcfg.ConstantinopleBlock)
 	}
+	if isForkIncompatible(c.TIP2019Block, newcfg.TIP2019Block, head) {
+		return newCompatError("TIP2019 fork block", c.TIP2019Block, newcfg.TIP2019Block)
+	}
+	if isForkIncompatible(c.TIPSigningBlock, newcfg.TIPSigningBlock, head) {
+		return newCompatError("TIPSigning fork block", c.TIPSigningBlock, newcfg.TIPSigningBlock)
+	}
+	if isForkIncompatible(c.TIPTomoXBlock, newcfg.TIPTomoXBlock, head) {
+		return newCompatError("TIPTomoX fork block", c.TIPTomoXBlock, newcfg.TIPTomoXBlock)
+	}
+	if isForkIncompatible(c.TIPTomoXLendingBlock, newcfg.TIPTomoXLendingBlock, head) {
+		return newCompatError("TIPTomoXLending fork block", c.TIPTomoXLendingBlock, newcfg.TIPTomoXLendingBlock)
+	}
+	if isForkIncompatible(c.TIPTomoXCancellationFeeBlock, newcfg.TIPTomoXCancellationFeeBlock, head) {
+		return newCompatError("TIPTomoXCancellationFee fork block", c.TIPTomoXCancellationFeeBlock, newcfg.TIPTomoXCancellationFeeBlock)
+	}
+	if isForkIncompatible(c.BlackListHFBlock, newcfg.BlackListHFBlock, head) {
+		return newCompatError("BlackListHF fork block", c.BlackListHFBlock, newcfg.BlackListHFBlock)
+	}
+	if isForkIncompatible(c.TIPTRC21FeeBlock, newcfg.TIPTRC21FeeBlock, head) {
+		return newCompatError("TIPTRC21Fee fork block", c.TIPTRC21FeeBlock, newcfg.TIPTRC21FeeBlock)
+	}
 	return nil
 }
 
@@ -425,6 +446,8 @@ type Rules struct {
 	ChainId                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
+	IsTIP2019, IsTIPSigning, IsTIPTomoX, IsTIPTomoXLending  bool
+	IsTIPTomoXCancellationFee, IsBlackListHF, IsTIPTRC21Fee bool
 }
 
 func (c *ChainConfig) Rules(num *big.Int) Rules {
@@ -433,14 +456,21 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		chainId = new(big.Int)
 	}
 	return Rules{
-		ChainId:          new(big.Int).Set(chainId),
-		IsHomestead:      c.IsHomestead(num),
-		IsEIP150:         c.IsEIP150(num),
-		IsEIP155:         c.IsEIP155(num),
-		IsEIP158:         c.IsEIP158(num),
-		IsByzantium:      c.IsByzantium(num),
-		IsConstantinople: c.IsConstantinople(num),
-		IsPetersburg:     c.IsPetersburg(num),
-		IsIstanbul:       c.IsIstanbul(num),
+		ChainId:                   new(big.Int).Set(chainId),
+		IsHomestead:               c.IsHomestead(num),
+		IsEIP150:                  c.IsEIP150(num),
+		IsEIP155:                  c.IsEIP155(num),
+		IsEIP158:                  c.IsEIP158(num),
+		IsByzantium:               c.IsByzantium(num),
+		IsConstantinople:          c.IsConstantinople(num),
+		IsPetersburg:              c.IsPetersburg(num),
+		IsIstanbul:                c.IsIstanbul(num),
+		IsTIP2019:                 c.IsTIP2019(num),
+		IsTIPSigning:              c.IsTIPSigning(num),
+		IsTIPTomoX:                c.IsTIPTomoX(num),
+		IsTIPTomoXLending:         c.IsTIPTomoXLending(num),
+		IsTIPTomoXCancellationFee: c.IsTIPTomoXCancellationFee(num),
+		IsBlackListHF:             c.IsBlackListHF(num),
+		IsTIPTRC21Fee:             c.IsTIPTRC21Fee(num),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -73,8 +73,10 @@ var (
 		TIPSigningBlock:              big.NewInt(0),
 		TIPRandomizeBlock:            big.NewInt(0),
 		BlackListHFBlock:             big.NewInt(0),
-		TIPTomoXCancellationFeeBlock: big.NewInt(0),
 		TIPTRC21FeeBlock:             big.NewInt(0),
+		TIPTomoXBlock:                big.NewInt(0),
+		TIPTomoXLendingBlock:         big.NewInt(0),
+		TIPTomoXCancellationFeeBlock: big.NewInt(0),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,

--- a/params/config.go
+++ b/params/config.go
@@ -90,7 +90,10 @@ var (
 		EIP155Block:                  big.NewInt(0),
 		EIP158Block:                  big.NewInt(0),
 		ByzantiumBlock:               big.NewInt(0),
+		TIPSigningBlock:              big.NewInt(0),
+		TIPRandomizeBlock:            big.NewInt(0),
 		TIPTomoXCancellationFeeBlock: big.NewInt(0),
+		TIPTRC21FeeBlock:             big.NewInt(0),
 		Ethash:                       new(EthashConfig),
 	}
 
@@ -100,13 +103,14 @@ var (
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
 	AllPosvProtocolChanges = &ChainConfig{
-		ChainId:        big.NewInt(89),
-		HomesteadBlock: big.NewInt(0),
-		EIP150Block:    big.NewInt(0),
-		EIP155Block:    big.NewInt(0),
-		EIP158Block:    big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
-		Posv:           &PosvConfig{Period: 0, Epoch: 30000},
+		ChainId:           big.NewInt(89),
+		HomesteadBlock:    big.NewInt(0),
+		EIP150Block:       big.NewInt(0),
+		EIP155Block:       big.NewInt(0),
+		EIP158Block:       big.NewInt(0),
+		ByzantiumBlock:    big.NewInt(0),
+		TIPRandomizeBlock: big.NewInt(0),
+		Posv:              &PosvConfig{Period: 0, Epoch: 30000},
 	}
 
 	TestChainConfig = &ChainConfig{

--- a/params/config.go
+++ b/params/config.go
@@ -32,13 +32,21 @@ var (
 var (
 	// TomoChain mainnet config
 	TomoMainnetChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(88),
-		HomesteadBlock: big.NewInt(1),
-		EIP150Block:    big.NewInt(2),
-		EIP150Hash:     common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-		EIP155Block:    big.NewInt(3),
-		EIP158Block:    big.NewInt(3),
-		ByzantiumBlock: big.NewInt(4),
+		ChainId:                      big.NewInt(88),
+		HomesteadBlock:               big.NewInt(1),
+		EIP150Block:                  big.NewInt(2),
+		EIP150Hash:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		EIP155Block:                  big.NewInt(3),
+		EIP158Block:                  big.NewInt(3),
+		ByzantiumBlock:               big.NewInt(4),
+		TIP2019Block:                 big.NewInt(1050000),
+		TIPSigningBlock:              big.NewInt(3000000),
+		TIPRandomizeBlock:            big.NewInt(3464000),
+		BlackListHFBlock:             big.NewInt(9349100),
+		TIPTomoXBlock:                big.NewInt(20581700),
+		TIPTomoXLendingBlock:         big.NewInt(21430200),
+		TIPTomoXCancellationFeeBlock: big.NewInt(30915660),
+		TIPTRC21FeeBlock:             big.NewInt(13523400),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,
@@ -49,34 +57,25 @@ var (
 		},
 	}
 
-	// MainnetChainConfig is the chain parameters to run a node on the main network.
-	MainnetChainConfig = &ChainConfig{
-		ChainId:             big.NewInt(1),
-		HomesteadBlock:      big.NewInt(1150000),
-		DAOForkBlock:        big.NewInt(1920000),
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(2463000),
-		EIP150Hash:          common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:         big.NewInt(2675000),
-		EIP158Block:         big.NewInt(2675000),
-		ByzantiumBlock:      big.NewInt(4370000),
-		ConstantinopleBlock: nil,
-		Ethash:              new(EthashConfig),
-	}
-
 	// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainId:             big.NewInt(3),
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(0),
-		EIP150Hash:          common.HexToHash("0x62e0fde86e34c263e250fbcd5ca4598ba8ca10a1d166c8526bb127e10b313311"),
-		EIP155Block:         big.NewInt(10),
-		EIP158Block:         big.NewInt(10),
-		ByzantiumBlock:      big.NewInt(1700000),
-		ConstantinopleBlock: nil,
-		Ethash:              new(EthashConfig),
+		ChainId:                      big.NewInt(3),
+		HomesteadBlock:               big.NewInt(0),
+		DAOForkBlock:                 nil,
+		DAOForkSupport:               true,
+		EIP150Block:                  big.NewInt(0),
+		EIP150Hash:                   common.HexToHash("0x62e0fde86e34c263e250fbcd5ca4598ba8ca10a1d166c8526bb127e10b313311"),
+		EIP155Block:                  big.NewInt(10),
+		EIP158Block:                  big.NewInt(10),
+		ByzantiumBlock:               big.NewInt(1700000),
+		ConstantinopleBlock:          nil,
+		TIP2019Block:                 big.NewInt(0),
+		TIPSigningBlock:              big.NewInt(0),
+		TIPRandomizeBlock:            big.NewInt(0),
+		BlackListHFBlock:             big.NewInt(0),
+		TIPTomoXCancellationFeeBlock: big.NewInt(0),
+		TIPTRC21FeeBlock:             big.NewInt(0),
+		Ethash:                       new(EthashConfig),
 	}
 
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced
@@ -84,17 +83,41 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
+	AllEthashProtocolChanges = &ChainConfig{
+		ChainId:                      big.NewInt(1337),
+		HomesteadBlock:               big.NewInt(0),
+		EIP150Block:                  big.NewInt(0),
+		EIP155Block:                  big.NewInt(0),
+		EIP158Block:                  big.NewInt(0),
+		ByzantiumBlock:               big.NewInt(0),
+		TIPTomoXCancellationFeeBlock: big.NewInt(0),
+		Ethash:                       new(EthashConfig),
+	}
 
 	// AllPosvProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Posv consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllPosvProtocolChanges   = &ChainConfig{big.NewInt(89), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &PosvConfig{Period: 0, Epoch: 30000}}
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
-	TestChainConfig          = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
-	TestRules                = TestChainConfig.Rules(new(big.Int))
+	AllPosvProtocolChanges = &ChainConfig{
+		ChainId:        big.NewInt(89),
+		HomesteadBlock: big.NewInt(0),
+		EIP150Block:    big.NewInt(0),
+		EIP155Block:    big.NewInt(0),
+		EIP158Block:    big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0),
+		Posv:           &PosvConfig{Period: 0, Epoch: 30000},
+	}
+
+	TestChainConfig = &ChainConfig{
+		ChainId:        big.NewInt(1),
+		HomesteadBlock: big.NewInt(0),
+		EIP150Block:    big.NewInt(0),
+		EIP155Block:    big.NewInt(0),
+		EIP158Block:    big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0),
+		Ethash:         new(EthashConfig),
+	}
 )
 
 // ChainConfig is the core config which determines the blockchain settings.
@@ -119,6 +142,15 @@ type ChainConfig struct {
 
 	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
+
+	TIP2019Block                 *big.Int `json:"tip2019Block,omitempty"`                 // TIP2019 switch block (nil = no fork, 0 = already activated)
+	TIPSigningBlock              *big.Int `json:"tipSigningBlock,omitempty"`              // TIPSigning switch block (nil = no fork, 0 = already activated)
+	TIPRandomizeBlock            *big.Int `json:"tipRandomizeBlock,omitempty"`            // TIPRandomize switch block (nil = no fork, 0 = already activated)
+	BlackListHFBlock             *big.Int `json:"blackListHFBlock,omitempty"`             // BlackListHF switch block (nil = no fork, 0 = already activated)
+	TIPTomoXBlock                *big.Int `json:"tipTomoXBlock,omitempty"`                // TIPTomoX switch block (nil = no fork, 0 = already activated)
+	TIPTomoXLendingBlock         *big.Int `json:"tipTomoXLendingBlock,omitempty"`         // TIPTomoXLending switch block (nil = no fork, 0 = already activated)
+	TIPTomoXCancellationFeeBlock *big.Int `json:"tipTomoXCancellationFeeBlock,omitempty"` // TIPTomoXCancellationFee switch block (nil = no fork, 0 = already activated)
+	TIPTRC21FeeBlock             *big.Int `json:"tipTRC21FeeBlock,omitempty"`             // TIPTRC21Fee switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
@@ -219,40 +251,44 @@ func (c *ChainConfig) IsConstantinople(num *big.Int) bool {
 // - equal to or greater than the PetersburgBlock fork block,
 // - OR is nil, and Constantinople is active
 func (c *ChainConfig) IsPetersburg(num *big.Int) bool {
-	return isForked(common.TIPTomoXCancellationFee, num)
+	return isForked(c.TIPTomoXCancellationFeeBlock, num)
 }
 
 // IsIstanbul returns whether num is either equal to the Istanbul fork block or greater.
 func (c *ChainConfig) IsIstanbul(num *big.Int) bool {
-	return isForked(common.TIPTomoXCancellationFee, num)
+	return isForked(c.TIPTomoXCancellationFeeBlock, num)
 }
 
 func (c *ChainConfig) IsTIP2019(num *big.Int) bool {
-	return isForked(common.TIP2019Block, num)
+	return isForked(c.TIP2019Block, num)
 }
 
 func (c *ChainConfig) IsTIPSigning(num *big.Int) bool {
-	return isForked(common.TIPSigning, num)
+	return isForked(c.TIPSigningBlock, num)
 }
 
 func (c *ChainConfig) IsTIPRandomize(num *big.Int) bool {
-	return isForked(common.TIPRandomize, num)
+	return isForked(c.TIPRandomizeBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoX(num *big.Int) bool {
-	if common.IsTestnet {
-		return isForked(common.TIPTomoXTestnet, num)
-	} else {
-		return isForked(common.TIPTomoX, num)
-	}
+	return isForked(c.TIPTomoXBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoXLending(num *big.Int) bool {
-	return isForked(common.TIPTomoXLending, num)
+	return isForked(c.TIPTomoXLendingBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoXCancellationFee(num *big.Int) bool {
-	return isForked(common.TIPTomoXCancellationFee, num)
+	return isForked(c.TIPTomoXCancellationFeeBlock, num)
+}
+
+func (c *ChainConfig) IsBlackListHF(num *big.Int) bool {
+	return isForked(c.BlackListHFBlock, num)
+}
+
+func (c *ChainConfig) IsTIPTRC21Fee(num *big.Int) bool {
+	return isForked(c.TIPTRC21FeeBlock, num)
 }
 
 // GasTable returns the gas table corresponding to the current phase (homestead or homestead reprice).

--- a/params/config.go
+++ b/params/config.go
@@ -114,13 +114,14 @@ var (
 	}
 
 	TestChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(1),
-		HomesteadBlock: big.NewInt(0),
-		EIP150Block:    big.NewInt(0),
-		EIP155Block:    big.NewInt(0),
-		EIP158Block:    big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
-		Ethash:         new(EthashConfig),
+		ChainId:         big.NewInt(1),
+		HomesteadBlock:  big.NewInt(0),
+		EIP150Block:     big.NewInt(0),
+		EIP155Block:     big.NewInt(0),
+		EIP158Block:     big.NewInt(0),
+		ByzantiumBlock:  big.NewInt(0),
+		TIPSigningBlock: big.NewInt(0),
+		Ethash:          new(EthashConfig),
 	}
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -79,24 +79,6 @@ var (
 		Ethash:              new(EthashConfig),
 	}
 
-	// RinkebyChainConfig contains the chain parameters to run a node on the Rinkeby test network.
-	RinkebyChainConfig = &ChainConfig{
-		ChainId:             big.NewInt(4),
-		HomesteadBlock:      big.NewInt(1),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      true,
-		EIP150Block:         big.NewInt(2),
-		EIP150Hash:          common.HexToHash("0x9b095b36c15eaf13044373aef8ee0bd3a382a5abb92e402afa44b8249c3a90e9"),
-		EIP155Block:         big.NewInt(3),
-		EIP158Block:         big.NewInt(3),
-		ByzantiumBlock:      big.NewInt(1035301),
-		ConstantinopleBlock: nil,
-		Posv: &PosvConfig{
-			Period: 15,
-			Epoch:  30000,
-		},
-	}
-
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Ethash consensus.
 	//

--- a/params/config.go
+++ b/params/config.go
@@ -43,10 +43,10 @@ var (
 		TIPSigningBlock:              big.NewInt(3000000),
 		TIPRandomizeBlock:            big.NewInt(3464000),
 		BlackListHFBlock:             big.NewInt(9349100),
+		TIPTRC21FeeBlock:             big.NewInt(13523400),
 		TIPTomoXBlock:                big.NewInt(20581700),
 		TIPTomoXLendingBlock:         big.NewInt(21430200),
 		TIPTomoXCancellationFeeBlock: big.NewInt(30915660),
-		TIPTRC21FeeBlock:             big.NewInt(13523400),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,
@@ -57,25 +57,32 @@ var (
 		},
 	}
 
-	// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
+	// TestnetChainConfig contains the chain parameters to run a node on the 2023 test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainId:                      big.NewInt(3),
+		ChainId:                      big.NewInt(89),
 		HomesteadBlock:               big.NewInt(0),
 		DAOForkBlock:                 nil,
-		DAOForkSupport:               true,
+		DAOForkSupport:               false,
 		EIP150Block:                  big.NewInt(0),
-		EIP150Hash:                   common.HexToHash("0x62e0fde86e34c263e250fbcd5ca4598ba8ca10a1d166c8526bb127e10b313311"),
-		EIP155Block:                  big.NewInt(10),
-		EIP158Block:                  big.NewInt(10),
-		ByzantiumBlock:               big.NewInt(1700000),
-		ConstantinopleBlock:          nil,
+		EIP150Hash:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		EIP155Block:                  big.NewInt(0),
+		EIP158Block:                  big.NewInt(0),
+		ByzantiumBlock:               big.NewInt(0),
+		ConstantinopleBlock:          big.NewInt(0),
 		TIP2019Block:                 big.NewInt(0),
 		TIPSigningBlock:              big.NewInt(0),
 		TIPRandomizeBlock:            big.NewInt(0),
 		BlackListHFBlock:             big.NewInt(0),
 		TIPTomoXCancellationFeeBlock: big.NewInt(0),
 		TIPTRC21FeeBlock:             big.NewInt(0),
-		Ethash:                       new(EthashConfig),
+		Posv: &PosvConfig{
+			Period:              2,
+			Epoch:               900,
+			Reward:              250,
+			RewardCheckpoint:    900,
+			Gap:                 5,
+			FoudationWalletAddr: common.HexToAddress("0x0000000000000000000000000000000000000068"),
+		},
 	}
 
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced

--- a/params/config.go
+++ b/params/config.go
@@ -93,7 +93,6 @@ var (
 		TIPSigningBlock:              big.NewInt(0),
 		TIPRandomizeBlock:            big.NewInt(0),
 		TIPTomoXCancellationFeeBlock: big.NewInt(0),
-		TIPTRC21FeeBlock:             big.NewInt(0),
 		Ethash:                       new(EthashConfig),
 	}
 

--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -21,22 +21,7 @@ import (
 
 	"math/big"
 
-	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/params"
-)
-
-var (
-	mainnetChainConfig = params.ChainConfig{
-		ChainId:        big.NewInt(1),
-		HomesteadBlock: big.NewInt(1150000),
-		DAOForkBlock:   big.NewInt(1920000),
-		DAOForkSupport: true,
-		EIP150Block:    big.NewInt(2463000),
-		EIP150Hash:     common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
-		EIP155Block:    big.NewInt(2675000),
-		EIP158Block:    big.NewInt(2675000),
-		ByzantiumBlock: big.NewInt(4370000),
-	}
 )
 
 func TestDifficulty(t *testing.T) {
@@ -69,9 +54,9 @@ func TestDifficulty(t *testing.T) {
 	})
 
 	dt.config("Frontier", *params.TestnetChainConfig)
-	dt.config("MainNetwork", mainnetChainConfig)
-	dt.config("CustomMainNetwork", mainnetChainConfig)
-	dt.config("difficulty.json", mainnetChainConfig)
+	dt.config("MainNetwork", *mainnetChainConfig)
+	dt.config("CustomMainNetwork", *mainnetChainConfig)
+	dt.config("difficulty.json", *mainnetChainConfig)
 
 	dt.walk(t, difficultyTestDir, func(t *testing.T, name string, test *DifficultyTest) {
 		cfg := dt.findConfig(name)

--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -41,8 +41,8 @@ func TestDifficulty(t *testing.T) {
 	dt.skipLoad("difficultyMorden\\.json")
 	dt.skipLoad("difficultyOlimpic\\.json")
 
-	dt.config("Ropsten", *params.TestnetChainConfig)
-	dt.config("Morden", *params.TestnetChainConfig)
+	dt.config("Ropsten", *ropstenChainConfig)
+	dt.config("Morden", *ropstenChainConfig)
 	dt.config("Frontier", params.ChainConfig{})
 
 	dt.config("Homestead", params.ChainConfig{
@@ -53,7 +53,7 @@ func TestDifficulty(t *testing.T) {
 		ByzantiumBlock: big.NewInt(0),
 	})
 
-	dt.config("Frontier", *params.TestnetChainConfig)
+	dt.config("Frontier", *ropstenChainConfig)
 	dt.config("MainNetwork", *mainnetChainConfig)
 	dt.config("CustomMainNetwork", *mainnetChainConfig)
 	dt.config("difficulty.json", *mainnetChainConfig)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestState(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	st := new(testMatcher)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestState(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
 	st := new(testMatcher)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -17,15 +17,12 @@
 package tests
 
 import (
-	"github.com/tomochain/tomochain/common"
-	"math/big"
 	"testing"
 
 	"github.com/tomochain/tomochain/core/vm"
 )
 
 func TestVM(t *testing.T) {
-	common.TIPTomoXCancellationFee=big.NewInt(100000000)
 	t.Parallel()
 	vmt := new(testMatcher)
 	vmt.fails("^vmSystemOperationsTest.json/createNameRegistrator$", "fails without parallel execution")

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -45,6 +45,18 @@ var (
 		EIP158Block:    big.NewInt(2675000),
 		ByzantiumBlock: big.NewInt(4370000),
 	}
+
+	ropstenChainConfig = &params.ChainConfig{
+		ChainId:             big.NewInt(3),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(10),
+		EIP158Block:         big.NewInt(10),
+		ByzantiumBlock:      big.NewInt(1_700_000),
+		ConstantinopleBlock: big.NewInt(4_230_000),
+	}
 )
 
 // VMTest checks EVM execution without block or transaction context.

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -20,17 +20,31 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"math/big"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/common/math"
 	"github.com/tomochain/tomochain/core"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/state"
 	"github.com/tomochain/tomochain/core/vm"
 	"github.com/tomochain/tomochain/crypto"
 	"github.com/tomochain/tomochain/params"
+)
+
+var (
+	mainnetChainConfig = &params.ChainConfig{
+		ChainId:        big.NewInt(1),
+		HomesteadBlock: big.NewInt(1150000),
+		DAOForkBlock:   big.NewInt(1920000),
+		DAOForkSupport: true,
+		EIP150Block:    big.NewInt(2463000),
+		EIP150Hash:     common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
+		EIP155Block:    big.NewInt(2675000),
+		EIP158Block:    big.NewInt(2675000),
+		ByzantiumBlock: big.NewInt(4370000),
+	}
 )
 
 // VMTest checks EVM execution without block or transaction context.
@@ -144,7 +158,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		GasPrice:    t.json.Exec.GasPrice,
 	}
 	vmconfig.NoRecursion = true
-	return vm.NewEVM(context, statedb, nil, params.MainnetChainConfig, vmconfig)
+	return vm.NewEVM(context, statedb, nil, mainnetChainConfig, vmconfig)
 }
 
 func vmTestBlockHash(n uint64) common.Hash {


### PR DESCRIPTION
This PR removes ugly fork blocks declared in `common/constants.go` and unifies the way how we check for forking using the methods of `params.ChainConfig`. The mainnet chain config (contains various fork blocks) can be configured in `params/config.go`
```go
// TomoChain mainnet config
TomoMainnetChainConfig = &ChainConfig{
    ChainId:                      big.NewInt(88),
    HomesteadBlock:               big.NewInt(1),
    EIP150Block:                  big.NewInt(2),
    EIP150Hash:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
    EIP155Block:                  big.NewInt(3),
    EIP158Block:                  big.NewInt(3),
    ByzantiumBlock:               big.NewInt(4),
    TIP2019Block:                 big.NewInt(1050000),
    TIPSigningBlock:              big.NewInt(3000000),
    TIPRandomizeBlock:            big.NewInt(3464000),
    BlackListHFBlock:             big.NewInt(9349100),
    TIPTomoXBlock:                big.NewInt(20581700),
    TIPTomoXLendingBlock:         big.NewInt(21430200),
    TIPTomoXCancellationFeeBlock: big.NewInt(30915660),
    TIPTRC21FeeBlock:             big.NewInt(13523400),
    Posv: &PosvConfig{
        Period:              2,
        Epoch:               900,
        Reward:              250,
        RewardCheckpoint:    900,
        Gap:                 5,
        FoudationWalletAddr: common.HexToAddress("0x0000000000000000000000000000000000000068"),
    },
    }
```
Similarly, the testnet fork blocks can be hardcoded at the same place
```go
// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
TestnetChainConfig = &ChainConfig{
    ChainId:                      big.NewInt(3),
    HomesteadBlock:               big.NewInt(0),
    DAOForkBlock:                 nil,
    DAOForkSupport:               true,
    EIP150Block:                  big.NewInt(0),
    EIP150Hash:                   common.HexToHash("0x62e0fde86e34c263e250fbcd5ca4598ba8ca10a1d166c8526bb127e10b313311"),
    EIP155Block:                  big.NewInt(10),
    EIP158Block:                  big.NewInt(10),
    ByzantiumBlock:               big.NewInt(1700000),
    ConstantinopleBlock:          nil,
    TIP2019Block:                 big.NewInt(0),
    TIPSigningBlock:              big.NewInt(0),
    TIPRandomizeBlock:            big.NewInt(0),
    BlackListHFBlock:             big.NewInt(0),
    TIPTomoXCancellationFeeBlock: big.NewInt(0),
    TIPTRC21FeeBlock:             big.NewInt(0),
    Ethash:                       new(EthashConfig),
}
```