### PR TITLE
Fix and optimize eth_estimateGas API

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -19,11 +19,11 @@ package abi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-        "errors"
 
-        "github.com/tomochain/tomochain/crypto"
+	"github.com/tomochain/tomochain/crypto"
 )
 
 // The ABI holds information about a contract's context and available
@@ -149,24 +149,24 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 }
 
 // revertSelector is a special function selector for revert reason unpacking.
- var revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
+var revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
 
- // UnpackRevert resolves the abi-encoded revert reason. According to the solidity
- // spec https://solidity.readthedocs.io/en/latest/control-structures.html#revert,
- // the provided revert reason is abi-encoded as if it were a call to a function
- // `Error(string)`. So it's a special tool for it.
- func UnpackRevert(data []byte) (string, error) {
- 	if len(data) < 4 {
- 		return "", errors.New("invalid data for unpacking")
- 	}
- 	if !bytes.Equal(data[:4], revertSelector) {
- 		return "", errors.New("invalid data for unpacking")
- 	}
- 	var reason string
- 	// typ, _ := NewType("string", "", nil)
- 	typ, _ := NewType("string")
- 	if err := (Arguments{{Type: typ}}).Unpack(&reason, data[4:]); err != nil {
- 		return "", err
- 	}
- 	return reason, nil
- }
+// UnpackRevert resolves the abi-encoded revert reason. According to the solidity
+// spec https://solidity.readthedocs.io/en/latest/control-structures.html#revert,
+// the provided revert reason is abi-encoded as if it were a call to a function
+// `Error(string)`. So it's a special tool for it.
+func UnpackRevert(data []byte) (string, error) {
+	if len(data) < 4 {
+		return "", errors.New("invalid data for unpacking")
+	}
+	if !bytes.Equal(data[:4], revertSelector) {
+		return "", errors.New("invalid data for unpacking")
+	}
+	var reason string
+	// typ, _ := NewType("string", "", nil)
+	typ, _ := NewType("string")
+	if err := (Arguments{{Type: typ}}).Unpack(&reason, data[4:]); err != nil {
+		return "", err
+	}
+	return reason, nil
+}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,6 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+        "errors"
+
+        "github.com/tomochain/tomochain/crypto"
 )
 
 // The ABI holds information about a contract's context and available
@@ -144,3 +147,26 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	}
 	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
 }
+
+// revertSelector is a special function selector for revert reason unpacking.
+ var revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
+
+ // UnpackRevert resolves the abi-encoded revert reason. According to the solidity
+ // spec https://solidity.readthedocs.io/en/latest/control-structures.html#revert,
+ // the provided revert reason is abi-encoded as if it were a call to a function
+ // `Error(string)`. So it's a special tool for it.
+ func UnpackRevert(data []byte) (string, error) {
+ 	if len(data) < 4 {
+ 		return "", errors.New("invalid data for unpacking")
+ 	}
+ 	if !bytes.Equal(data[:4], revertSelector) {
+ 		return "", errors.New("invalid data for unpacking")
+ 	}
+ 	var reason string
+ 	// typ, _ := NewType("string", "", nil)
+ 	typ, _ := NewType("string")
+ 	if err := (Arguments{{Type: typ}}).Unpack(&reason, data[4:]); err != nil {
+ 		return "", err
+ 	}
+ 	return reason, nil
+ }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -19,9 +19,9 @@ package abi
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
-        "errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -620,16 +620,19 @@ func TestBareEvents(t *testing.T) {
 }
 
 // TestUnpackEvent is based on this contract:
-//    contract T {
-//      event received(address sender, uint amount, bytes memo);
-//      event receivedAddr(address sender);
-//      function receive(bytes memo) external payable {
-//        received(msg.sender, msg.value, memo);
-//        receivedAddr(msg.sender);
-//      }
-//    }
+//
+//	contract T {
+//	  event received(address sender, uint amount, bytes memo);
+//	  event receivedAddr(address sender);
+//	  function receive(bytes memo) external payable {
+//	    received(msg.sender, msg.value, memo);
+//	    receivedAddr(msg.sender);
+//	  }
+//	}
+//
 // When receive("X") is called with sender 0x00... and value 1, it produces this tx receipt:
-//   receipt{status=1 cgas=23949 bloom=00000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000040200000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 logs=[log: b6818c8064f645cd82d99b59a1a267d6d61117ef [75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed] 000000000000000000000000376c47978271565f56deb45495afa69e59c16ab200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158 9ae378b6d4409eada347a5dc0c180f186cb62dc68fcc0f043425eb917335aa28 0 95d429d309bb9d753954195fe2d69bd140b4ae731b9b5b605c34323de162cf00 0]}
+//
+//	receipt{status=1 cgas=23949 bloom=00000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000040200000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 logs=[log: b6818c8064f645cd82d99b59a1a267d6d61117ef [75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed] 000000000000000000000000376c47978271565f56deb45495afa69e59c16ab200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158 9ae378b6d4409eada347a5dc0c180f186cb62dc68fcc0f043425eb917335aa28 0 95d429d309bb9d753954195fe2d69bd140b4ae731b9b5b605c34323de162cf00 0]}
 func TestUnpackEvent(t *testing.T) {
 	const abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"receivedAddr","type":"event"}]`
 	abi, err := JSON(strings.NewReader(abiJSON))
@@ -716,32 +719,32 @@ func TestABI_MethodById(t *testing.T) {
 }
 
 func TestUnpackRevert(t *testing.T) {
- 	t.Parallel()
+	t.Parallel()
 
- 	var cases = []struct {
- 		input     string
- 		expect    string
- 		expectErr error
- 	}{
- 		{"", "", errors.New("invalid data for unpacking")},
- 		{"08c379a1", "", errors.New("invalid data for unpacking")},
- 		{"08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e00000000000000000000000000000000000000", "revert reason", nil},
- 	}
- 	for index, c := range cases {
- 		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
- 			got, err := UnpackRevert(common.Hex2Bytes(c.input))
- 			if c.expectErr != nil {
- 				if err == nil {
- 					t.Fatalf("Expected non-nil error")
- 				}
- 				if err.Error() != c.expectErr.Error() {
- 					t.Fatalf("Expected error mismatch, want %v, got %v", c.expectErr, err)
- 				}
- 				return
- 			}
- 			if c.expect != got {
- 				t.Fatalf("Output mismatch, want %v, got %v", c.expect, got)
- 			}
- 		})
- 	}
- }
+	var cases = []struct {
+		input     string
+		expect    string
+		expectErr error
+	}{
+		{"", "", errors.New("invalid data for unpacking")},
+		{"08c379a1", "", errors.New("invalid data for unpacking")},
+		{"08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e00000000000000000000000000000000000000", "revert reason", nil},
+	}
+	for index, c := range cases {
+		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
+			got, err := UnpackRevert(common.Hex2Bytes(c.input))
+			if c.expectErr != nil {
+				if err == nil {
+					t.Fatalf("Expected non-nil error")
+				}
+				if err.Error() != c.expectErr.Error() {
+					t.Fatalf("Expected error mismatch, want %v, got %v", c.expectErr, err)
+				}
+				return
+			}
+			if c.expect != got {
+				t.Fatalf("Output mismatch, want %v, got %v", c.expect, got)
+			}
+		})
+	}
+}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+        "errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -713,3 +714,34 @@ func TestABI_MethodById(t *testing.T) {
 	}
 
 }
+
+func TestUnpackRevert(t *testing.T) {
+ 	t.Parallel()
+
+ 	var cases = []struct {
+ 		input     string
+ 		expect    string
+ 		expectErr error
+ 	}{
+ 		{"", "", errors.New("invalid data for unpacking")},
+ 		{"08c379a1", "", errors.New("invalid data for unpacking")},
+ 		{"08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e00000000000000000000000000000000000000", "revert reason", nil},
+ 	}
+ 	for index, c := range cases {
+ 		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
+ 			got, err := UnpackRevert(common.Hex2Bytes(c.input))
+ 			if c.expectErr != nil {
+ 				if err == nil {
+ 					t.Fatalf("Expected non-nil error")
+ 				}
+ 				if err.Error() != c.expectErr.Error() {
+ 					t.Fatalf("Expected error mismatch, want %v, got %v", c.expectErr, err)
+ 				}
+ 				return
+ 			}
+ 			if c.expect != got {
+ 				t.Fatalf("Output mismatch, want %v, got %v", c.expect, got)
+ 			}
+ 		})
+ 	}
+ }

--- a/core/error.go
+++ b/core/error.go
@@ -38,4 +38,11 @@ var (
 	ErrNotFoundM1 = errors.New("list M1 not found ")
 
 	ErrStopPreparingBlock = errors.New("stop calculating a block not verified by M2")
+
+        // ErrGasUintOverflow is returned when calculating gas usage.
+ 	ErrGasUintOverflow = errors.New("gas uint64 overflow")
+
+        // ErrInsufficientFundsForTransfer is returned if the transaction sender doesn't
+ 	// have enough funds for transfer(topmost call only).
+ 	ErrInsufficientFundsForTransfer = errors.New("insufficient funds for transfer")
 )

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -76,6 +76,40 @@ type Message interface {
 	BalanceTokenFee() *big.Int
 }
 
+// message no matter the execution itself is successful or not.
+ type ExecutionResult struct {
+ 	UsedGas    uint64 // Total used gas but include the refunded gas
+ 	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
+ 	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+ }
+
+ // Unwrap returns the internal evm error which allows us for further
+ // analysis outside.
+ func (result *ExecutionResult) Unwrap() error {
+ 	return result.Err
+ }
+
+ // Failed returns the indicator whether the execution is successful or not
+ func (result *ExecutionResult) Failed() bool { return result.Err != nil }
+
+ // Return is a helper function to help caller distinguish between revert reason
+ // and function return. Return returns the data after execution if no error occurs.
+ func (result *ExecutionResult) Return() []byte {
+ 	if result.Err != nil {
+ 		return nil
+ 	}
+ 	return common.CopyBytes(result.ReturnData)
+ }
+
+ // Revert returns the concrete revert reason if the execution is aborted by `REVERT`
+ // opcode. Note the reason can be nil if no data supplied with revert opcode.
+ func (result *ExecutionResult) Revert() []byte {
+ 	if result.Err != vm.ErrExecutionReverted {
+ 		return nil
+ 	}
+ 	return common.CopyBytes(result.ReturnData)
+ }
+
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
 func IntrinsicGas(data []byte, contractCreation, homestead bool) (uint64, error) {
 	// Set the starting gas for the raw transaction

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/core/vm"
-	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/params"
 )
 
@@ -130,13 +129,13 @@ func IntrinsicGas(data []byte, contractCreation, homestead bool) (uint64, error)
 		}
 		// Make sure we don't exceed uint64 for all data combinations
 		if (math.MaxUint64-gas)/params.TxDataNonZeroGas < nz {
-			return 0, vm.ErrOutOfGas
+			return 0, ErrGasUintOverflow
 		}
 		gas += nz * params.TxDataNonZeroGas
 
 		z := uint64(len(data)) - nz
 		if (math.MaxUint64-gas)/params.TxDataZeroGas < z {
-			return 0, vm.ErrOutOfGas
+			return 0, ErrGasUintOverflow
 		}
 		gas += z * params.TxDataZeroGas
 	}
@@ -163,7 +162,7 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 // the gas used (which includes gas refunds) and an error if it failed. An error always
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
-func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool, owner common.Address) ([]byte, uint64, bool, error) {
+func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool, owner common.Address) (*ExecutionResult, error) {
 	return NewStateTransition(evm, msg, gp).TransitionDb(owner)
 }
 
@@ -193,15 +192,6 @@ func (st *StateTransition) to() vm.AccountRef {
 		st.state.CreateAccount(*to)
 	}
 	return reference
-}
-
-func (st *StateTransition) useGas(amount uint64) error {
-	if st.gas < amount {
-		return vm.ErrOutOfGas
-	}
-	st.gas -= amount
-
-	return nil
 }
 
 func (st *StateTransition) buyGas() error {
@@ -247,11 +237,32 @@ func (st *StateTransition) preCheck() error {
 }
 
 // TransitionDb will transition the state by applying the current message and
-// returning the result including the the used gas. It returns an error if it
-// failed. An error indicates a consensus issue.
-func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedGas uint64, failed bool, err error) {
-	if err = st.preCheck(); err != nil {
-		return
+// returning the evm execution result with following fields.
+//
+// - used gas:
+//      total gas used (including gas being refunded)
+// - returndata:
+//      the returned data from evm
+// - concrete execution error:
+//      various **EVM** error which aborts the execution,
+//      e.g. ErrOutOfGas, ErrExecutionReverted
+//
+// However if any consensus issue encountered, return the error directly with
+// nil evm execution result.
+func (st *StateTransition) TransitionDb(owner common.Address) (*ExecutionResult, error) {
+        // First check this message satisfies all consensus rules before
+ 	// applying the message. The rules include these clauses
+ 	//
+ 	// 1. the nonce of the message caller is correct
+ 	// 2. caller has enough balance to cover transaction fee(gaslimit * gasprice)
+ 	// 3. the amount of gas required is available in the block
+ 	// 4. the purchased gas is enough to cover intrinsic usage
+ 	// 5. there is no overflow when calculating intrinsic gas
+ 	// 6. caller has enough balance to cover asset transfer for **topmost** call
+
+ 	// Check clauses 1-3, buy gas if everything is correct
+        if err := st.preCheck(); err != nil {
+		return nil, err
 	}
 	msg := st.msg
 	sender := st.from() // err checked in preCheck
@@ -259,44 +270,35 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 	homestead := st.evm.ChainConfig().IsHomestead(st.evm.BlockNumber)
 	contractCreation := msg.To() == nil
 
-	// Pay intrinsic gas
+        // Check clauses 4-5, substract intrinsic gas if everything is correct
 	gas, err := IntrinsicGas(st.data, contractCreation, homestead)
 	if err != nil {
-		return nil, 0, false, err
+		return nil, err
 	}
-	if err = st.useGas(gas); err != nil {
-		return nil, 0, false, err
-	}
+        if st.gas < gas {
+                return nil, ErrIntrinsicGas
+        }
+        st.gas -= gas
+
+        // check clause 6
+        if msg.Value().Sign() > 0 && !st.evm.CanTransfer(st.state, msg.From(), msg.Value()) {
+                return nil, ErrInsufficientFundsForTransfer
+        }
 
 	var (
-		evm = st.evm
-		// vm errors do not effect consensus and are therefor
-		// not assigned to err, except for insufficient balance
-		// error.
-		vmerr error
+                ret     []byte
+                vmerr   error
 	)
 	// for debugging purpose
 	// TODO: clean it after fixing the issue https://github.com/tomochain/tomochain/issues/401
-	var contractAction string
 	nonce := uint64(1)
 	if contractCreation {
-		ret, _, st.gas, vmerr = evm.Create(sender, st.data, st.gas, st.value)
-		contractAction = "contract creation"
+		ret, _, st.gas, vmerr = st.evm.Create(sender, st.data, st.gas, st.value)
 	} else {
 		// Increment the nonce for the next transaction
 		nonce = st.state.GetNonce(sender.Address()) + 1
 		st.state.SetNonce(sender.Address(), nonce)
-		ret, st.gas, vmerr = evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
-		contractAction = "contract call"
-	}
-	if vmerr != nil {
-		log.Debug("VM returned with error", "action", contractAction, "contract address", st.to().Address(), "gas", st.gas, "gasPrice", st.gasPrice, "nonce", nonce, "err", vmerr)
-		// The only possible consensus-error would be if there wasn't
-		// sufficient balance to make the transfer happen. The first
-		// balance transfer may never fail.
-		if vmerr == vm.ErrInsufficientBalance {
-			return nil, 0, false, vmerr
-		}
+		ret, st.gas, vmerr = st.evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
 	}
 	st.refundGas()
 
@@ -308,7 +310,11 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 	}
 
-	return ret, st.gasUsed(), vmerr != nil, err
+	return &ExecutionResult{
+                UsedGas:        st.gasUsed(),
+                Err:            vmerr,
+                ReturnData:     ret,
+        }, err
 }
 
 func (st *StateTransition) refundGas() {

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -111,11 +111,11 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 	vmenv := vm.NewEVM(evmContext, statedb, nil, chain.Config(), vm.Config{})
 	gaspool := new(GasPool).AddGas(1000000)
 	owner := common.Address{}
-	rval, _, _, err := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
+	result, err := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
 	if err != nil {
 		return nil, err
 	}
-	return rval, err
+	return result.Return(), err
 }
 
 // make sure that balance of token is at slot 0

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -474,7 +474,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 		vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})
 		owner := common.Address{}
-		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
 			failed = err
 			break
 		}
@@ -630,7 +630,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	vmenv := vm.NewEVM(vmctx, statedb, nil, api.config, vm.Config{Debug: true, Tracer: tracer})
 
 	owner := common.Address{}
-	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), owner)
+	result, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), owner)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}
@@ -638,9 +638,9 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	switch tracer := tracer.(type) {
 	case *vm.StructLogger:
 		return &ethapi.ExecutionResult{
-			Gas:         gas,
-			Failed:      failed,
-			ReturnValue: fmt.Sprintf("%x", ret),
+			Gas:         result.UsedGas,
+			Failed:      result.Failed(),
+			ReturnValue: fmt.Sprintf("%x", result.Return()),
 			StructLogs:  ethapi.FormatLogs(tracer.StructLogs()),
 		}, nil
 

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -20,17 +20,18 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"io/ioutil"
 	"math/big"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/hexutil"
 	"github.com/tomochain/tomochain/common/math"
 	"github.com/tomochain/tomochain/core"
+	"github.com/tomochain/tomochain/core/rawdb"
 	"github.com/tomochain/tomochain/core/types"
 	"github.com/tomochain/tomochain/core/vm"
 	"github.com/tomochain/tomochain/crypto"
@@ -183,7 +184,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-	if _, _, _, err = st.TransitionDb(common.Address{}); err != nil {
+	if _, err = st.TransitionDb(common.Address{}); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
 	// Retrieve the trace result and compare against the etalon
@@ -258,7 +259,7 @@ func TestCallTracer(t *testing.T) {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
 			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-			if _, _, _, err = st.TransitionDb(common.Address{}); err != nil {
+			if _, err = st.TransitionDb(common.Address{}); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}
 			// Retrieve the trace result and compare against the etalon

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -510,7 +510,7 @@ func (s *PublicBlockChainAPI) BlockNumber() *big.Int {
 	return header.Number
 }
 
-// BlockNumber returns the block number of the chain head.
+// GetRewardByHash returns the block reward by block hash.
 func (s *PublicBlockChainAPI) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	return s.b.GetRewardByHash(hash)
 }
@@ -1026,17 +1026,21 @@ type CallArgs struct {
 	Data     hexutil.Bytes   `json:"data"`
 }
 
-func (s *PublicBlockChainAPI) doCall(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, timeout time.Duration) (*core.ExecutionResult, error) {
+func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, timeout time.Duration) (*core.ExecutionResult, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
-	statedb, header, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
-	if statedb == nil || err != nil {
+	state, header, err := b.StateAndHeaderByNumber(ctx, blockNr)
+	if state == nil || err != nil {
 		return nil, err
 	}
+
+	return doCall(ctx, b, args, state, header, timeout)
+}
+func doCall(ctx context.Context, b Backend, args CallArgs, state *state.StateDB, header *types.Header, timeout time.Duration) (*core.ExecutionResult, error) {
 	// Set sender address or use a default if none specified
 	addr := args.From
 	if addr == (common.Address{}) {
-		if wallets := s.b.AccountManager().Wallets(); len(wallets) > 0 {
+		if wallets := b.AccountManager().Wallets(); len(wallets) > 0 {
 			if accounts := wallets[0].Accounts(); len(accounts) > 0 {
 				addr = accounts[0].Address
 			}
@@ -1067,20 +1071,20 @@ func (s *PublicBlockChainAPI) doCall(ctx context.Context, args CallArgs, blockNr
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	block, err := s.b.BlockByNumber(ctx, blockNr)
+	block, err := b.BlockByNumber(ctx, rpc.BlockNumber(header.Number.Int64()))
 	if err != nil {
 		return nil, err
 	}
-	author, err := s.b.GetEngine().Author(block.Header())
+	author, err := b.GetEngine().Author(block.Header())
 	if err != nil {
 		return nil, err
 	}
-	tomoxState, err := s.b.TomoxService().GetTradingState(block, author)
+	tomoxState, err := b.TomoxService().GetTradingState(block, author)
 	if err != nil {
 		return nil, err
 	}
 	// Get a new instance of the EVM.
-	evm, vmError, err := s.b.GetEVM(ctx, msg, statedb, tomoxState, header, vmCfg)
+	evm, vmError, err := b.GetEVM(ctx, msg, state, tomoxState, header, vm.Config{})
 	if err != nil {
 		return nil, err
 	}
@@ -1135,7 +1139,7 @@ func (e *revertError) ErrorData() interface{} {
 // Call executes the given transaction on the state for the given block number.
 // It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
-	result, err := s.doCall(ctx, args, blockNr, vm.Config{}, 5*time.Second)
+	result, err := DoCall(ctx, s.b, args, blockNr, vm.Config{}, 5*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -1146,45 +1150,107 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr r
 	return result.Return(), result.Err
 }
 
-// EstimateGas returns an estimate of the amount of gas needed to execute the
-// given transaction against the current pending block.
-func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (hexutil.Uint64, error) {
-	// Binary search the gas requirement, as it may be higher than the amount used
+// executeEstimate is a helper that executes the transaction under a given gas limit and returns
+// true if the transaction fails for a reason that might be related to not enough gas. A non-nil
+// error means execution failed due to reasons unrelated to the gas limit.
+func executeEstimate(ctx context.Context, b Backend, args CallArgs, state *state.StateDB, header *types.Header, gasLimit uint64) (bool, *core.ExecutionResult, error) {
+	args.Gas = (hexutil.Uint64)(gasLimit)
+	result, err := doCall(ctx, b, args, state, header, 0)
+	if err != nil {
+		if errors.Is(err, core.ErrIntrinsicGas) {
+			return true, nil, nil // Special case, raise gas limit
+		}
+		return true, nil, err // Bail out
+	}
+	return result.Failed(), result, nil
+}
+
+// DoEstimateGas returns the lowest possible gas limit that allows the transaction to run
+// successfully at block `blockNrOrHash`. It returns error if the transaction would revert, or if
+// there are unexpected failures. The gas limit is capped by both `args.Gas` (if non-nil &
+// non-zero) and `gasCap` (if non-zero).
+func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumber) (hexutil.Uint64, error) {
+	// Binary search the gas limit, as it may need to be higher than the amount used
 	var (
-		lo  uint64 = params.TxGas - 1
-		hi  uint64
-		cap uint64
+		lo uint64 // lowest-known gas limit where tx execution fails
+		hi uint64 // lowest-known gas limit where tx execution succeeds
 	)
+	// Determine the highest gas limit can be used during the estimation.
 	if uint64(args.Gas) >= params.TxGas {
 		hi = uint64(args.Gas)
 	} else {
-		// Retrieve the current pending block to act as the gas ceiling
-		block, err := s.b.BlockByNumber(ctx, rpc.LatestBlockNumber)
+		// Retrieve the block to act as the gas ceiling
+		block, err := b.BlockByNumber(ctx, blockNrOrHash)
 		if err != nil {
 			return 0, err
 		}
+		if block == nil {
+			return 0, errors.New("block not found")
+		}
 		hi = block.GasLimit()
 	}
-	cap = hi
+	// Normalize the max fee per gas the call is willing to spend.
+	feeCap := args.GasPrice.ToInt()
 
-	// Create a helper to check if a gas allowance results in an executable transaction
-	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
-		args.Gas = hexutil.Uint64(gas)
-
-		result, err := s.doCall(ctx, args, rpc.LatestBlockNumber, vm.Config{}, 0)
-		if err != nil {
-			if err == core.ErrIntrinsicGas {
-				return true, nil, nil // Special case, raise gas limit
-			}
-			return true, nil, err
-		}
-		return result.Failed(), result, nil
+	state, header, err := b.StateAndHeaderByNumber(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return 0, err
 	}
-	// Execute the binary search and hone in on an executable gas limit
+
+	// Recap the highest gas limit with account's available balance.
+	if feeCap.BitLen() != 0 {
+		balance := state.GetBalance(args.From) // from can't be nil
+		available := new(big.Int).Set(balance)
+		if args.Value.ToInt().Cmp(available) >= 0 {
+			return 0, core.ErrInsufficientFundsForTransfer
+		}
+		available.Sub(available, args.Value.ToInt())
+		allowance := new(big.Int).Div(available, feeCap)
+
+		// If the allowance is larger than maximum uint64, skip checking
+		if allowance.IsUint64() && hi > allowance.Uint64() {
+			transfer := args.Value
+			log.Warn("Gas estimation capped by limited funds", "original", hi, "balance", balance,
+				"sent", transfer.ToInt(), "maxFeePerGas", feeCap, "fundable", allowance)
+			hi = allowance.Uint64()
+		}
+	}
+
+	// We first execute the transaction at the highest allowable gas limit, since if this fails we
+	// can return error immediately.
+	failed, result, err := executeEstimate(ctx, b, args, state.Copy(), header, hi)
+	if err != nil {
+		return 0, err
+	}
+	if failed {
+		if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
+			if len(result.Revert()) > 0 {
+				return 0, newRevertError(result)
+			}
+			return 0, result.Err
+		}
+		return 0, fmt.Errorf("gas required exceeds allowance (%d)", hi)
+	}
+	// For almost any transaction, the gas consumed by the unconstrained execution above
+	// lower-bounds the gas limit required for it to succeed. One exception is those txs that
+	// explicitly check gas remaining in order to successfully execute within a given limit, but we
+	// probably don't want to return a lowest possible gas limit for these cases anyway.
+	lo = result.UsedGas - 1
+
+	// Binary search for the smallest gas limit that allows the tx to execute successfully.
 	for lo+1 < hi {
 		mid := (hi + lo) / 2
-		failed, _, err := executable(mid)
+		if mid > lo*2 {
+			// Most txs don't need much higher gas limit than their gas used, and most txs don't
+			// require near the full block limit of gas, so the selection of where to bisect the
+			// range here is skewed to favor the low side.
+			mid = lo * 2
+		}
+		failed, _, err = executeEstimate(ctx, b, args, state.Copy(), header, mid)
 		if err != nil {
+			// This should not happen under normal conditions since if we make it this far the
+			// transaction had run without error at least once before.
+			log.Error("execution error in estimate gas", "err", err)
 			return 0, err
 		}
 		if failed {
@@ -1193,24 +1259,20 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 			hi = mid
 		}
 	}
-	// Reject the transaction as invalid if it still fails at the highest allowance
-	if hi == cap {
-		failed, result, err := executable(hi)
-		if err != nil {
-			return 0, nil
-		}
-
-		if failed {
-			if result != nil && result.Err != vm.ErrOutOfGas {
-				if len(result.Revert()) > 0 {
-					return 0, newRevertError(result)
-				}
-				return 0, result.Err
-			}
-			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
-		}
-	}
 	return hexutil.Uint64(hi), nil
+}
+
+// EstimateGas returns the lowest possible gas limit that allows the transaction to run
+// successfully at block `blockNrOrHash`, or the latest block if `blockNrOrHash` is unspecified. It
+// returns error if the transaction would revert or if there are unexpected failures. The returned
+// value is capped by both `args.Gas` (if non-nil & non-zero) and the backend's RPCGasCap
+// configuration (if non-zero).
+func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, blockNrOrHash *rpc.BlockNumber) (hexutil.Uint64, error) {
+	bNrOrHash := rpc.LatestBlockNumber
+	if blockNrOrHash != nil {
+		bNrOrHash = *blockNrOrHash
+	}
+	return DoEstimateGas(ctx, s.b, args, bNrOrHash)
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -141,8 +141,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
 				owner := common.Address{}
-				ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
-				res = append(res, ret...)
+				ret, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+				res = append(res, ret.Return()...)
 			}
 		} else {
 			header := lc.GetHeaderByHash(bhash)
@@ -158,9 +158,9 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			vmenv := vm.NewEVM(context, statedb, nil, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			owner := common.Address{}
-			ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+			ret, _:= core.ApplyMessage(vmenv, msg, gp, owner)
 			if statedb.Error() == nil {
-				res = append(res, ret...)
+				res = append(res, ret.Return()...)
 			}
 		}
 	}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -188,8 +188,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		vmenv := vm.NewEVM(context, st, nil, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		owner := common.Address{}
-		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
-		res = append(res, ret...)
+		ret, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+		res = append(res, ret.Return()...)
 		if st.Error() != nil {
 			return res, st.Error()
 		}

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -56,8 +56,6 @@ type jsonError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
-
-
 type jsonErrResponse struct {
 	Version string      `json:"jsonrpc"`
 	Id      interface{} `json:"id,omitempty"`
@@ -99,8 +97,8 @@ func (err *jsonError) ErrorCode() int {
 }
 
 func (err *jsonError) ErrorData() interface{} {
- 	return err.Data
- }
+	return err.Data
+}
 
 // NewCodec creates a new RPC server codec with support for JSON-RPC 2.0 based
 // on explicitly given encoding and decoding methods.

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -56,6 +56,8 @@ type jsonError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+
+
 type jsonErrResponse struct {
 	Version string      `json:"jsonrpc"`
 	Id      interface{} `json:"id,omitempty"`
@@ -95,6 +97,10 @@ func (err *jsonError) Error() string {
 func (err *jsonError) ErrorCode() int {
 	return err.Code
 }
+
+func (err *jsonError) ErrorData() interface{} {
+ 	return err.Data
+ }
 
 // NewCodec creates a new RPC server codec with support for JSON-RPC 2.0 based
 // on explicitly given encoding and decoding methods.

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -144,7 +144,7 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	snapshot := statedb.Snapshot()
 
 	coinbase := &t.json.Env.Coinbase
-	if _, _, _, err := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
+	if _, err := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	if logs := rlpHash(statedb.Logs()); logs != common.Hash(post.Logs) {


### PR DESCRIPTION
Prerequisite:

- [ ] https://github.com/BuildOnViction/tomochain/pull/366

This PR add a `rpc.BlockNumber` input parameters for `eth_estimateGas` API because most 3rd-party tools (such as MetaMask, Remix IDE, etc.) require the same parameters for this API.

`EstimateGas` repeatedly executes a transaction, performing a binary search with multiple gas prices to determine proper pricing. Each call retrieves a new copy of the state https://github.com/BuildOnViction/tomochain/blob/76420ee3ba79120351018b86c1a84c4001ad9064/internal/ethapi/api.go#L1136
Because the pending/latest state can be changed during the execution of `EstimateGas`, this can potentially cause strange behaviors. `EstimateGas` currently conducts a binary search to determine a suitable gas limit for a tx, and continues searching with a higher gas limit whenever the transaction's execution results in revert. While this makes sense if the reason for revert is out of gas, increasing the gas limit is highly unlikely to allow a non-OOG reverting transaction to succeed (unless it is making unusual use of the GAS opcode).

This PR modifies EstimateGas to retrieve the state once and use a copy of it for every call invocation it does. This has two benefits:

- Saves compute overhead.
- Eliminates a race condition where a reverting transaction causes the gas limit lowerbound to increase repeatedly during gas estimation, only for a state change to allow the transaction to later succeed later in the loop, resulting in an unreasonably high estimate being returned. (We believe this is happening in practice in one of our applications)

Resolve issue:
- https://github.com/BuildOnViction/tomochain/issues/390

Supersede:
- https://github.com/BuildOnViction/tomochain/pull/391

Reference:
- https://github.com/ethereum/go-ethereum/pull/27710