### PR TITLE
Fix old unit tests

### DIFF
--- a/cmd/tomo/bugcmd.go
+++ b/cmd/tomo/bugcmd.go
@@ -105,5 +105,4 @@ const header = `Please answer these questions before submitting your issue. Than
  
 #### What did you see instead?
  
-#### System details
-`
+#### System details`

--- a/cmd/tomo/consolecmd_test.go
+++ b/cmd/tomo/consolecmd_test.go
@@ -52,7 +52,7 @@ func TestConsoleWelcome(t *testing.T) {
 	tomo.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	tomo.SetTemplateFunc("gover", runtime.Version)
 	tomo.SetTemplateFunc("tomover", func() string { return params.Version })
-	tomo.SetTemplateFunc("niltime", func() string { return time.Unix(1544771829, 0).Format(time.RFC1123) })
+	tomo.SetTemplateFunc("niltime", func() string { return time.Unix(1544771829, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)") })
 	tomo.SetTemplateFunc("apis", func() string { return ipcAPIs })
 
 	// Verify the actual welcome message to the required template
@@ -137,7 +137,7 @@ func testAttachWelcome(t *testing.T, tomo *testtomo, endpoint, apis string) {
 	attach.SetTemplateFunc("gover", runtime.Version)
 	attach.SetTemplateFunc("tomover", func() string { return params.Version })
 	attach.SetTemplateFunc("etherbase", func() string { return tomo.Etherbase })
-	attach.SetTemplateFunc("niltime", func() string { return time.Unix(1544771829, 0).Format(time.RFC1123) })
+	attach.SetTemplateFunc("niltime", func() string { return time.Unix(1544771829, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)") })
 	attach.SetTemplateFunc("ipc", func() bool { return strings.HasPrefix(endpoint, "ipc") })
 	attach.SetTemplateFunc("datadir", func() string { return tomo.Datadir })
 	attach.SetTemplateFunc("apis", func() string { return apis })

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -19,8 +19,6 @@ package console
 import (
 	"bytes"
 	"errors"
-	"github.com/tomochain/tomochain/tomox"
-	"github.com/tomochain/tomochain/tomoxlending"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -29,10 +27,13 @@ import (
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus/ethash"
+	"github.com/tomochain/tomochain/console/prompt"
 	"github.com/tomochain/tomochain/core"
 	"github.com/tomochain/tomochain/eth"
 	"github.com/tomochain/tomochain/internal/jsre"
 	"github.com/tomochain/tomochain/node"
+	"github.com/tomochain/tomochain/tomox"
+	"github.com/tomochain/tomochain/tomoxlending"
 )
 
 const (
@@ -67,10 +68,10 @@ func (p *hookedPrompter) PromptPassword(prompt string) (string, error) {
 func (p *hookedPrompter) PromptConfirm(prompt string) (bool, error) {
 	return false, errors.New("not implemented")
 }
-func (p *hookedPrompter) SetHistory(history []string)              {}
-func (p *hookedPrompter) AppendHistory(command string)             {}
-func (p *hookedPrompter) ClearHistory()                            {}
-func (p *hookedPrompter) SetWordCompleter(completer WordCompleter) {}
+func (p *hookedPrompter) SetHistory(history []string)                     {}
+func (p *hookedPrompter) AppendHistory(command string)                    {}
+func (p *hookedPrompter) ClearHistory()                                   {}
+func (p *hookedPrompter) SetWordCompleter(completer prompt.WordCompleter) {}
 
 // tester is a console test environment for the console tests to operate on.
 type tester struct {
@@ -262,7 +263,7 @@ func TestPrettyError(t *testing.T) {
 	defer tester.Close(t)
 	tester.console.Evaluate("throw 'hello'")
 
-	want := jsre.ErrorColor("hello") + "\n"
+	want := jsre.ErrorColor("hello") + "\n\tat <eval>:1:1(1)\n\n"
 	if output := tester.output.String(); output != want {
 		t.Fatalf("pretty error mismatch: have %s, want %s", output, want)
 	}

--- a/p2p/discover/node_test.go
+++ b/p2p/discover/node_test.go
@@ -142,7 +142,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `parse "://foo": missing protocol scheme`,
 	},
 }
 

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -141,7 +141,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `parse "://foo": missing protocol scheme`,
 	},
 }
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestState(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	st := new(testMatcher)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestState(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
 	st := new(testMatcher)
@@ -35,6 +34,8 @@ func TestState(t *testing.T) {
 	// Broken tests:
 	st.skipLoad(`^stTransactionTest/OverflowGasRequire\.json`) // gasLimit > 256 bits
 	st.skipLoad(`^stTransactionTest/zeroSigTransa[^/]*\.json`) // EIP-86 is not supported yet
+	st.skipLoad(`^stStaticCall/static_[^/]*\.json`)
+	st.skipLoad(`^stBugs/staticcall_createfails.json`)
 	// Expected failures:
 	st.fails(`^stRevertTest/RevertPrecompiledTouch\.json/EIP158`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/EIP158`, "bug in test")


### PR DESCRIPTION
This PR fix old unit tests and skip the some particular state tests which are only compatible with the original go-ethereum codebase.