### PR TITLE
Skip nonce check when run tracer

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -250,7 +250,7 @@ func ApplyTransaction(config *params.ChainConfig, tokensFee map[common.Address]*
 			balanceFee = value
 		}
 	}
-	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), balanceFee, header.Number)
+	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), balanceFee, header.Number, true)
 	if err != nil {
 		return nil, 0, err, false
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -247,7 +247,7 @@ func (tx *Transaction) Size() common.StorageSize {
 // AsMessage requires a signer to derive the sender.
 //
 // XXX Rename message to something less arbitrary?
-func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int) (Message, error) {
+func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int, checkNonce bool) (Message, error) {
 	msg := Message{
 		nonce:           tx.data.AccountNonce,
 		gasLimit:        tx.data.GasLimit,
@@ -255,7 +255,7 @@ func (tx *Transaction) AsMessage(s Signer, balanceFee *big.Int, number *big.Int)
 		to:              tx.data.Recipient,
 		amount:          tx.data.Amount,
 		data:            tx.data.Payload,
-		checkNonce:      true,
+		checkNonce:      checkNonce,
 		balanceTokenFee: balanceFee,
 	}
 	var err error

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -439,13 +439,13 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				feeCapacity := state.GetTRC21FeeCapacityFromState(task.statedb)
-				var balacne *big.Int
+				var balance *big.Int
 				if txs[task.index].To() != nil {
 					if value, ok := feeCapacity[*txs[task.index].To()]; ok {
-						balacne = value
+						balance = value
 					}
 				}
-				msg, _ := txs[task.index].AsMessage(signer, balacne, block.Number(), false)
+				msg, _ := txs[task.index].AsMessage(signer, balance, block.Number(), false)
 				vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
@@ -463,14 +463,14 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	for i, tx := range txs {
 		// Send the trace task over for execution
 		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}
-		var balacne *big.Int
+		var balance *big.Int
 		if tx.To() != nil {
 			if value, ok := feeCapacity[*tx.To()]; ok {
-				balacne = value
+				balance = value
 			}
 		}
 		// Generate the next state snapshot fast without tracing
-		msg, _ := tx.AsMessage(signer, balacne, block.Number(), false)
+		msg, _ := tx.AsMessage(signer, balance, block.Number(), false)
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -627,6 +627,9 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	default:
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
+	if message.To().String() == common.TradingStateAddr || message.To().String() == common.TomoXLendingAddress || message.To().String() == common.TomoXAddr || message.To().String() == common.TomoXLendingFinalizedTradeAddress {
+		return &ethapi.ExecutionResult{}, nil
+	}
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, nil, api.config, vm.Config{Debug: true, Tracer: tracer})
 

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -641,7 +641,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
 	if message.To().String() == common.TradingStateAddr || message.To().String() == common.TomoXLendingAddress || message.To().String() == common.TomoXAddr || message.To().String() == common.TomoXLendingFinalizedTradeAddress {
-		// update temp nonce for the address
+		// update temp nonce for the address to by pass the nonce check
 		statedb.SetNonce(message.From(), message.Nonce())
 	}
 	// Run the transaction with tracing enabled.

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -205,7 +205,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 							balacne = value
 						}
 					}
-					msg, _ := tx.AsMessage(signer, balacne, task.block.Number())
+					msg, _ := tx.AsMessage(signer, balacne, task.block.Number(), false)
 					vmctx := core.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
 
 					res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
@@ -445,7 +445,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 						balacne = value
 					}
 				}
-				msg, _ := txs[task.index].AsMessage(signer, balacne, block.Number())
+				msg, _ := txs[task.index].AsMessage(signer, balacne, block.Number(), false)
 				vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
@@ -470,7 +470,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			}
 		}
 		// Generate the next state snapshot fast without tracing
-		msg, _ := tx.AsMessage(signer, balacne, block.Number())
+		msg, _ := tx.AsMessage(signer, balacne, block.Number(), false)
 		// Run trace for each type of transaction
 		if tx.To() != nil && tx.To().String() == common.TradingStateAddr {
 			continue
@@ -640,10 +640,6 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	default:
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
-	if message.To().String() == common.TradingStateAddr || message.To().String() == common.TomoXLendingAddress || message.To().String() == common.TomoXAddr || message.To().String() == common.TomoXLendingFinalizedTradeAddress {
-		// update temp nonce for the address to by pass the nonce check
-		statedb.SetNonce(message.From(), message.Nonce())
-	}
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, nil, api.config, vm.Config{Debug: true, Tracer: tracer})
 
@@ -705,7 +701,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 					balanceFee = value
 				}
 			}
-			msg, err := tx.AsMessage(types.MakeSigner(api.config, block.Header().Number), balanceFee, block.Number())
+			msg, err := tx.AsMessage(types.MakeSigner(api.config, block.Header().Number), balanceFee, block.Number(), false)
 			if err != nil {
 				return nil, vm.Context{}, nil, fmt.Errorf("tx %x failed: %v", tx.Hash(), err)
 			}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -471,25 +471,13 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer, balacne, block.Number(), false)
-		// Run trace for each type of transaction
-		if tx.To() != nil && tx.To().String() == common.TradingStateAddr {
-			continue
-		} else if tx.To() != nil && tx.To().String() == common.TomoXLendingAddress {
-			continue
-		} else if tx.IsTradingTransaction() {
-			continue
-		} else if tx.IsLendingFinalizedTradeTransaction() {
-			continue
-		} else {
-			// only open EVM with normal transaction
-			vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
-			vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})
-			owner := common.Address{}
-			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
-				failed = err
-				break
-			}
+		vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})
+		owner := common.Address{}
+		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
+			failed = err
+			break
 		}
 
 		// Finalize the state so any modifications are written to the trie

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -199,13 +199,13 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				feeCapacity := state.GetTRC21FeeCapacityFromState(task.statedb)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
-					var balacne *big.Int
+					var balance *big.Int
 					if tx.To() != nil {
 						if value, ok := feeCapacity[*tx.To()]; ok {
-							balacne = value
+							balance = value
 						}
 					}
-					msg, _ := tx.AsMessage(signer, balacne, task.block.Number(), false)
+					msg, _ := tx.AsMessage(signer, balance, task.block.Number(), false)
 					vmctx := core.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
 
 					res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -628,7 +628,12 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
 	if message.To().String() == common.TradingStateAddr || message.To().String() == common.TomoXLendingAddress || message.To().String() == common.TomoXAddr || message.To().String() == common.TomoXLendingFinalizedTradeAddress {
-		return &ethapi.ExecutionResult{}, nil
+		return &ethapi.ExecutionResult{
+			Gas:         0,
+			Failed:      false,
+			ReturnValue: "",
+			StructLogs:  make([]ethapi.StructLogRes, 0),
+		}, nil
 	}
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, nil, api.config, vm.Config{Debug: true, Tracer: tracer})

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -179,7 +179,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	}
 	evm := vm.NewEVM(context, statedb, nil, params.MainnetChainConfig, vm.Config{Debug: true, Tracer: tracer})
 
-	msg, err := tx.AsMessage(signer, nil, nil)
+	msg, err := tx.AsMessage(signer, nil, nil, false)
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestCallTracer(t *testing.T) {
 			}
 			evm := vm.NewEVM(context, statedb, nil, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
 
-			msg, err := tx.AsMessage(signer, nil, common.Big0)
+			msg, err := tx.AsMessage(signer, nil, common.Big0, false)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}


### PR DESCRIPTION
Some transactions created by internal nodes don’t update the sender’s nonce, leading to an invalid nonce check when running block or transaction traces.

This PR disables the nonce check when a trace is run.

Squash merge #466