### PR TITLE
Fix mismatch BlockHash between block header and transaction logs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1750,7 +1750,11 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 	if verifiedM2 {
 		if result, check := bc.resultProcess.Get(block.HashNoValidator()); check {
 			log.Debug("Get result block from cache ", "number", block.NumberU64(), "hash", block.Hash(), "hash no validator", block.HashNoValidator())
-			return result.(*ResultProcessBlock), nil
+			b := result.(*ResultProcessBlock)
+			for _, log := range b.logs {
+				log.BlockHash = block.Hash()
+			}
+			return b, nil
 		}
 		log.Debug("Not found cache prepare block ", "number", block.NumberU64(), "hash", block.Hash(), "validator", block.HashNoValidator())
 		if calculatedBlock, _ := bc.calculatingBlock.Get(block.HashNoValidator()); calculatedBlock != nil {

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -259,6 +259,9 @@ func GetBlockReceipts(db DatabaseReader, hash common.Hash, number uint64) types.
 	receipts := make(types.Receipts, len(storageReceipts))
 	for i, receipt := range storageReceipts {
 		receipts[i] = (*types.Receipt)(receipt)
+		for _, receiptLog := range receipts[i].Logs {
+			receiptLog.BlockHash = hash
+		}
 	}
 	return receipts
 }


### PR DESCRIPTION
This pull request fixes a mismatch between the block hash in the block header and the transaction logs.

- For blocks stored in the database before this PR, the stored `blockHash` may be mismatched, but we can send back to users the correct `blockHash`.

- For newly created blocks, the `blockHash` is set to correct `blockHash` before storing to the database.