### PR TITLE
Skip verify header when trace block

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -403,6 +403,12 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
 	// Create the parent state database
 	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+	if block.NumberU64() > common.TIPSigningBlock.Uint64() {
+		// only verify header for block number > TIPSigning
+		if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
+			return nil, err
+		}
+	}
 	if parent == nil {
 		return nil, fmt.Errorf("parent %x not found", block.ParentHash())
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -402,9 +402,6 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 // per transaction, dependent on the requestd tracer.
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
 	// Create the parent state database
-	// if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
-		// return nil, err
-	// }
 	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
 		return nil, fmt.Errorf("parent %x not found", block.ParentHash())

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -401,14 +401,14 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 // executes all the transactions contained within. The return value will be one item
 // per transaction, dependent on the requestd tracer.
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
-	// Create the parent state database
-	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if block.NumberU64() > common.TIPSigningBlock.Uint64() {
 		// only verify header for block number > TIPSigning
 		if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
 			return nil, err
 		}
 	}
+	// Create the parent state database
+	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
 		return nil, fmt.Errorf("parent %x not found", block.ParentHash())
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -402,9 +402,9 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 // per transaction, dependent on the requestd tracer.
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
 	// Create the parent state database
-	if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
-		return nil, err
-	}
+	// if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
+		// return nil, err
+	// }
 	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
 		return nil, fmt.Errorf("parent %x not found", block.ParentHash())


### PR DESCRIPTION
When running the trace API for block numbers below 3M (**TIPSigning**), the node returns an invalid penalty list on checkpoint blocks due to the use of the old HookPenalty.

The old **HookPenalty** uses the latest statedb to calculate the penalty list, which relies on the state of the BlockSigner contract. However, in the latest statedb, the code and data of the **BlockSigner** contract are removed by **TIPSigningBlock**: https://github.com/BuildOnViction/victionchain/blob/a7014d392753c8a872200188fe4023315cb3f460/miner/worker.go#L623

Removing the header verification for block < **TIPSigning** can fix this issue. We will cover trace bad block in future PR