### PR TITLE
fix(eth/api_tracer): remove verify header

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -401,12 +401,6 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 // executes all the transactions contained within. The return value will be one item
 // per transaction, dependent on the requestd tracer.
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
-	if block.NumberU64() > common.TIPSigningBlock.Uint64() {
-		// only verify header for block number > TIPSigning
-		if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
-			return nil, err
-		}
-	}
 	// Create the parent state database
 	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {


### PR DESCRIPTION
Few block headers has been panic when run tracing.
- Remove header verification when trace block
- Implementation of trace bad block will be in the future PR