### PR TITLE
feat(internal/ethapi/api): Ask transaction pool for the nonce which includes pending transactions

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1617,6 +1617,15 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx cont
 
 // GetTransactionCount returns the number of transactions the given address has sent for the given block number
 func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
+	// Ask transaction pool for the nonce which includes pending transactions
+	if blockNr == rpc.PendingBlockNumber {
+		nonce, err := s.b.GetPoolNonce(ctx, address)
+		if err != nil {
+			return nil, err
+		}
+		return (*hexutil.Uint64)(&nonce), nil
+	}
+
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
 	if state == nil || err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, GetTransactionCount uses StateAndHeaderByNumber to get the nonce from the pending state. But, only the miner knows the pending state so if the local node is not a miner, then the state used to get the nonce will not include any pending transactions that the sender has submitted.

It seems that GetTransactionCount should ask the local node's transaction pool for the nonce if we want the pending nonce to include pending transactions.

Mirror: https://github.com/ethereum/go-ethereum/pull/15794