### PR TITLE
Feat: Combine '--mine' and '--slave' into one, make relevant account-related flags optional

### DIFF
--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -129,11 +129,10 @@ func defaultNodeConfig() node.Config {
 func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 	// Load defaults.
 	cfg := tomoConfig{
-		Eth:   eth.DefaultConfig,
-		Shh:   whisper.DefaultConfig,
-		TomoX: tomox.DefaultConfig,
-		Node:  defaultNodeConfig(),
-		// StakeEnable: true,
+		Eth:       eth.DefaultConfig,
+		Shh:       whisper.DefaultConfig,
+		TomoX:     tomox.DefaultConfig,
+		Node:      defaultNodeConfig(),
 		Verbosity: 3,
 		NAT:       "",
 	}
@@ -143,9 +142,7 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 			utils.Fatalf("%v", err)
 		}
 	}
-	// if ctx.GlobalIsSet(utils.StakingEnabledFlag.Name) {
-	// 	cfg.StakeEnable = ctx.GlobalBool(utils.StakingEnabledFlag.Name)
-	// }
+
 	if !ctx.GlobalIsSet(debug.VerbosityFlag.Name) {
 		debug.Glogger.Verbosity(log.Lvl(cfg.Verbosity))
 	}

--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -129,13 +129,13 @@ func defaultNodeConfig() node.Config {
 func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 	// Load defaults.
 	cfg := tomoConfig{
-		Eth:         eth.DefaultConfig,
-		Shh:         whisper.DefaultConfig,
-		TomoX:       tomox.DefaultConfig,
-		Node:        defaultNodeConfig(),
-		StakeEnable: true,
-		Verbosity:   3,
-		NAT:         "",
+		Eth:   eth.DefaultConfig,
+		Shh:   whisper.DefaultConfig,
+		TomoX: tomox.DefaultConfig,
+		Node:  defaultNodeConfig(),
+		// StakeEnable: true,
+		Verbosity: 3,
+		NAT:       "",
 	}
 	// Load config file.
 	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
@@ -143,9 +143,9 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 			utils.Fatalf("%v", err)
 		}
 	}
-	if ctx.GlobalIsSet(utils.StakingEnabledFlag.Name) {
-		cfg.StakeEnable = ctx.GlobalBool(utils.StakingEnabledFlag.Name)
-	}
+	// if ctx.GlobalIsSet(utils.StakingEnabledFlag.Name) {
+	// 	cfg.StakeEnable = ctx.GlobalBool(utils.StakingEnabledFlag.Name)
+	// }
 	if !ctx.GlobalIsSet(debug.VerbosityFlag.Name) {
 		debug.Glogger.Verbosity(log.Lvl(cfg.Verbosity))
 	}

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -298,6 +298,7 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			started := false
 			miningEnable := ctx.GlobalIsSet(utils.StakingEnabledFlag.Name)
 
+			defer close(core.CheckpointCh)
 			if miningEnable {
 				log.Info("Staking mode enabled.")
 				ok, err := ethereum.ValidateMasternode()
@@ -324,7 +325,6 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					log.Info("Enabled staking node!!!")
 				}
 
-				defer close(core.CheckpointCh)
 				for range core.CheckpointCh {
 					log.Info("Checkpoint!!! It's time to reconcile node's state...")
 					ok, err := ethereum.ValidateMasternode()
@@ -360,6 +360,9 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 				}
 			} else {
 				log.Info("Staking mode disabled.")
+				for range core.CheckpointCh {
+					log.Info("Checkpoint!!! It's time to reconcile node's state...")
+				}
 			}
 		}()
 	}

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -127,7 +127,6 @@ var (
 		utils.AnnounceTxsFlag,
 		utils.StoreRewardFlag,
 		utils.RollbackFlag,
-		// utils.TomoSlaveModeFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -556,10 +556,6 @@ var (
 		Name:  "tomox.dbReplicaSetName",
 		Usage: "ReplicaSetName if Master-Slave is setup",
 	}
-	// TomoSlaveModeFlag = cli.BoolFlag{
-	// 	Name:  "slave",
-	// 	Usage: "Enable slave mode",
-	// }
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -556,10 +556,10 @@ var (
 		Name:  "tomox.dbReplicaSetName",
 		Usage: "ReplicaSetName if Master-Slave is setup",
 	}
-	TomoSlaveModeFlag = cli.BoolFlag{
-		Name:  "slave",
-		Usage: "Enable slave mode",
-	}
+	// TomoSlaveModeFlag = cli.BoolFlag{
+	// 	Name:  "slave",
+	// 	Usage: "Enable slave mode",
+	// }
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -237,7 +237,7 @@ func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendi
 		signHook := func(block *types.Block) error {
 			eb, err := eth.Etherbase()
 			if err != nil {
-				log.Error("Cannot get etherbase for append m2 header", "err", err)
+				log.Warn("Cannot get etherbase for append m2 header", "err", err)
 				return fmt.Errorf("etherbase missing: %v", err)
 			}
 			ok := eth.txPool.IsSigner != nil && eth.txPool.IsSigner(eb)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -237,7 +237,7 @@ func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendi
 		signHook := func(block *types.Block) error {
 			eb, err := eth.Etherbase()
 			if err != nil {
-				log.Warn("Cannot get etherbase for append m2 header", "err", err)
+				log.Error("Cannot get etherbase for append m2 header", "err", err)
 				return fmt.Errorf("etherbase missing: %v", err)
 			}
 			ok := eth.txPool.IsSigner != nil && eth.txPool.IsSigner(eb)
@@ -284,8 +284,10 @@ func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendi
 			return block, false, nil
 		}
 
-		eth.protocolManager.fetcher.SetSignHook(signHook)
-		eth.protocolManager.fetcher.SetAppendM2HeaderHook(appendM2HeaderHook)
+		if ctx.GetConfig().KeyStoreDir != "" {
+			eth.protocolManager.fetcher.SetSignHook(signHook)
+			eth.protocolManager.fetcher.SetAppendM2HeaderHook(appendM2HeaderHook)
+		}
 
 		// Hook prepares validators M2 for the current epoch at checkpoint block
 		c.HookValidator = func(header *types.Header, signers []common.Address) ([]byte, error) {

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -19,9 +19,10 @@ package fetcher
 
 import (
 	"errors"
-	"github.com/hashicorp/golang-lru"
 	"math/rand"
 	"time"
+
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"
@@ -717,7 +718,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 
 		if f.signHook != nil {
 			if err := f.signHook(block); err != nil {
-				log.Error("Can't sign the imported block", "err", err)
+				log.Warn("Can't sign the imported block", "err", err)
 				return
 			}
 		}

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -19,10 +19,9 @@ package fetcher
 
 import (
 	"errors"
+	"github.com/hashicorp/golang-lru"
 	"math/rand"
 	"time"
-
-	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/consensus"

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -718,7 +718,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 
 		if f.signHook != nil {
 			if err := f.signHook(block); err != nil {
-				log.Warn("Can't sign the imported block", "err", err)
+				log.Error("Can't sign the imported block", "err", err)
 				return
 			}
 		}


### PR DESCRIPTION
### Description
This pull request introduces two key changes to improve flexibility and usability:

**1. Make relevant account-related flags optional**
- A non-mining node does not require an account. Therefore, the `--keystore`, `--password` and `--unlock` flags can be optional and should only be required when a mining node lacks an account.

**2. Combine `--mine` and `--slave` flags into one**
- Currently, the `--mine` flag is defined but not used in any scenario. The `--slave` flag is used when a master node wants to become a full node. To make this clearer, we can combine these into a single flag. If a full node wants to act as a master node, it can stake and enable the `--mine` flag along with relevant account-related flags. Conversely, if a master node wants to operate as a full node, it can disable the `--mine` flag and the associated account-related flags.

### Changes overview
> Masternode (Mining node)
> Fullnode (Non-mining node)
#### Current
|                        | Use `--mine` | Use `--slave` | Require Account | 
| ------------- | ------------- | ------------- | ------------- |
| Masternode  | ❌  | ❌   | ✅   | 
| Fullnode  | ❌ | ✅  | ✅  | 
#### Propose
|                        | Use `--mine` | Use `--slave` | Require Account | 
| ------------- | ------------- | ------------- | ------------- |
| Masternode  | ✅ | Deprecate  | ✅  | 
| Fullnode  | ❌ | Deprecate  | ❌  |

