### PR TITLE
core/blockchain: add some metrics for monitoring block and state

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -74,6 +74,9 @@ var (
 	blockExecutionTimer  = metrics.NewRegisteredTimer("chain/execution", nil)
 	blockWriteTimer      = metrics.NewRegisteredTimer("chain/write", nil)
 
+	blockReorgAddMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
+	blockReorgDropMeter = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
+
 	CheckpointCh = make(chan int)
 	ErrNoGenesis = errors.New("Genesis not found in chain")
 )
@@ -2239,12 +2242,16 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	}
 	// Ensure the user sees large reorgs
 	if len(oldChain) > 0 && len(newChain) > 0 {
-		logFn := log.Debug
+		logFn := log.Info
+		msg := "Chain reorg detected"
 		if len(oldChain) > 63 {
+			msg = "Large chain reorg detected"
 			logFn = log.Warn
 		}
-		logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
+		logFn(msg, "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
+		blockReorgAddMeter.Mark(int64(len(newChain)))
+		blockReorgDropMeter.Mark(int64(len(oldChain)))
 	} else {
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "newnum", newBlock.Number(), "newhash", newBlock.Hash())
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -74,8 +74,10 @@ var (
 	blockExecutionTimer  = metrics.NewRegisteredTimer("chain/execution", nil)
 	blockWriteTimer      = metrics.NewRegisteredTimer("chain/write", nil)
 
-	blockReorgAddMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
-	blockReorgDropMeter = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
+	blockReorgMeter         = metrics.NewRegisteredMeter("chain/reorg/executes", nil)
+	blockReorgAddMeter      = metrics.NewRegisteredMeter("chain/reorg/add", nil)
+	blockReorgDropMeter     = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
+	blockReorgInvalidatedTx = metrics.NewRegisteredMeter("chain/reorg/invalidTx", nil)
 
 	CheckpointCh = make(chan int)
 	ErrNoGenesis = errors.New("Genesis not found in chain")
@@ -2252,6 +2254,7 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
 		blockReorgAddMeter.Mark(int64(len(newChain)))
 		blockReorgDropMeter.Mark(int64(len(oldChain)))
+		blockReorgMeter.Mark(1)
 	} else {
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "newnum", newBlock.Number(), "newhash", newBlock.Hash())
 	}


### PR DESCRIPTION
### Prerequisites: 
- Merge this PR first: https://github.com/BuildOnViction/victionchain/pull/497

This pull request introduces significant changes to the Viction codebase, primarily focusing on enhancing metrics collection and reporting. The changes include the addition of new metrics, refactoring existing flags, and updating various parts of the blockchain and state management code to track and report metrics more effectively.

### Metrics Enhancements:

* Added new metrics for tracking various blockchain and state operations, including block insertion, validation, execution, and storage updates. (`core/blockchain.go`, `core/state/state_object.go`, `core/state/statedb.go`) [[1]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R367) [[2]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R380-R385) [[3]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R449-R451) [[4]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R475) [[5]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R608-R612) [[6]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R710) [[7]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R728) [[8]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1040-R1046) [[9]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1168) [[10]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1674-R1708) [[11]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1725-R1728) [[12]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215L2188-R2257) [[13]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R175-R178) [[14]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R241-R246) [[15]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R264-R269) [[16]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R280-R285) [[17]](diffhunk://#diff-c3757dc9e9d868f63bc84a0cc67159c1d5c22cc5d8c9468757098f0492e0658cR85-R94) [[18]](diffhunk://#diff-c3757dc9e9d868f63bc84a0cc67159c1d5c22cc5d8c9468757098f0492e0658cR374-R380)
* Track the head header, receipt and block via gauges. This gives us access to the sync status without RPC.
```
	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)

	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)
	accountHashTimer   = metrics.NewRegisteredTimer("chain/account/hashes", nil)
	accountUpdateTimer = metrics.NewRegisteredTimer("chain/account/updates", nil)
	accountCommitTimer = metrics.NewRegisteredTimer("chain/account/commits", nil)

	storageReadTimer   = metrics.NewRegisteredTimer("chain/storage/reads", nil)
	storageHashTimer   = metrics.NewRegisteredTimer("chain/storage/hashes", nil)
	storageUpdateTimer = metrics.NewRegisteredTimer("chain/storage/updates", nil)
	storageCommitTimer = metrics.NewRegisteredTimer("chain/storage/commits", nil)

	blockInsertTimer     = metrics.NewRegisteredTimer("chain/inserts", nil)
	blockValidationTimer = metrics.NewRegisteredTimer("chain/validation", nil)
	blockExecutionTimer  = metrics.NewRegisteredTimer("chain/execution", nil)
	blockWriteTimer      = metrics.NewRegisteredTimer("chain/write", nil)

	blockReorgMeter         = metrics.NewRegisteredMeter("chain/reorg/executes", nil)
	blockReorgAddMeter      = metrics.NewRegisteredMeter("chain/reorg/add", nil)
	blockReorgDropMeter     = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
	blockReorgInvalidatedTx = metrics.NewRegisteredMeter("chain/reorg/invalidTx", nil)
```

### Code Refactoring:

* Refactored the import paths and usage of the `metrics` package across various files to ensure consistency and avoid redundancy. (`cmd/utils/flags.go`, `core/blockchain.go`, `core/headerchain.go`, `core/state/state_object.go`, `core/state/statedb.go`) [[1]](diffhunk://#diff-7aa83061ca1c69a8ab9203da49a7581bad6e7cc80ecb96582e7fb09c0b8f6534L46) [[2]](diffhunk://#diff-7aa83061ca1c69a8ab9203da49a7581bad6e7cc80ecb96582e7fb09c0b8f6534L359-R364) [[3]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R24-R28) [[4]](diffhunk://#diff-c3757dc9e9d868f63bc84a0cc67159c1d5c22cc5d8c9468757098f0492e0658cR25-R31)

### Additional Changes:

* Updated the logging mechanism to provide more informative messages during chain reorganization and other critical operations. (`core/blockchain.go`)
* Ensured that various gauges and timers are updated correctly to reflect the current state of the blockchain and header chain. (`core/blockchain.go`, `core/headerchain.go`) [[1]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R367) [[2]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R380-R385) [[3]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R449-R451) [[4]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R475) [[5]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R608-R612) [[6]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R710) [[7]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R728) [[8]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1040-R1046) [[9]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1168) [[10]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1674-R1708) [[11]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215R1725-R1728) [[12]](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215L2188-R2257) [[13]](diffhunk://#diff-86d95b78d5baafdd89b2477b79a269dff6433414b0ba15eb3eff8961e440bb4cR107) [[14]](diffhunk://#diff-86d95b78d5baafdd89b2477b79a269dff6433414b0ba15eb3eff8961e440bb4cR189) [[15]](diffhunk://#diff-86d95b78d5baafdd89b2477b79a269dff6433414b0ba15eb3eff8961e440bb4cR405) [[16]](diffhunk://#diff-86d95b78d5baafdd89b2477b79a269dff6433414b0ba15eb3eff8961e440bb4cR444)

These changes collectively aim to improve the observability and performance monitoring of the Viction system, making it easier to diagnose issues and optimize the blockchain's performance.

### Reference:
- https://github.com/ethereum/go-ethereum/pull/18119
- https://github.com/ethereum/go-ethereum/pull/19692
- https://github.com/ethereum/go-ethereum/pull/21420