### PR TITLE
Custom P2P Port for Docker image

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -15,23 +15,29 @@ WORKDIR /tomochain
 COPY --from=builder /tomochain/build/bin/tomo /usr/local/bin/tomo
 
 ENV IDENTITY ''
-ENV PASSWORD ''
-ENV PRIVATE_KEY ''
+ENV NETWORK_ID '88'
+ENV SYNC_MODE 'full'
 ENV BOOTNODES ''
 ENV EXTIP ''
-ENV VERBOSITY 3
-ENV SYNC_MODE 'full'
-ENV NETWORK_ID '88'
-ENV WS_SECRET ''
+ENV P2P_PORT '30303'
+ENV MAX_PEERS '25'
 ENV NETSTATS_HOST 'netstats-server'
 ENV NETSTATS_PORT '3000'
+ENV WS_SECRET ''
+ENV PASSWORD ''
+ENV PRIVATE_KEY ''
 ENV ANNOUNCE_TXS ''
+ENV DEBUG_MODE ''
+ENV STORE_REWARD ''
+ENV VERBOSITY 3
 
 RUN apk add --no-cache ca-certificates
 
 COPY docker/tomochain ./
 COPY genesis/ ./
 
-EXPOSE 8545 8546 30303 30303/udp
+EXPOSE 8545
+EXPOSE 8546
+EXPOSE ${P2P_PORT} ${P2P_PORT}/udp
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ go1.18.10 run build/ci.go install
 Clone this repository and change working directory to where you clone it, then run the following commands:
 
 ```bash
-docker build --file Dockerfile.node -t "viction:2.4.4" .
+docker build --file Dockerfile.node -t "local/viction:v2.4.4" .
 ```
 
 ### Pre-built Bianries
@@ -140,22 +140,25 @@ docker run --name viction \
   -e NETSTATS_PORT=443 \
   -e WS_SECRET=getty-site-pablo-auger-room-sos-blair-shin-whiz-delhi \
   -e VERBOSITY=3 \
-  buildonviction/node:2.4.4
+  buildonviction/node:v2.4.4
 ```
 
 Brief explainations on the supported variables:
 
 ```text
-EXTIP: Your IP on the internet to let other peers connect to your nodes. Only use this if you have trouble connecting to peers.
 IDENTITY: your full node's name.
-PRIVATE_KEY: Private key of node's account in plain text.
-PASSWORD: Password to encrypt/decrypt node's account in plain text.
 NETWORK_ID: our network ID.
 BOOTNODES: list of enodes of other peers that your full-node will try to connect at startup.
+EXTIP: Your IP on the internet to let other peers connect to your nodes. Only use this if you have trouble connecting to peers.
+P2P_PORT: Port to let other peers to connect to your node. Must map host port the same with configured P2P port.
+MAX_PEERS: Max number of peers allowed to connect with your host. Set to 0 to disable P2P.
 NETSTATS_HOST: Hostname of Ethstats service.
 NETSTATS_PORT: Port of Ethstats service.
 WS_SECRET: Secret of Ethstats service.
-DEBUG_MODE: Enable archive mode.
+PRIVATE_KEY: Private key of node's account in plain text.
+PASSWORD: Password to encrypt/decrypt node's account in plain text.
+DEBUG_MODE: Enable archive mode and debug APIs. Empty for disable.
+STORE_REWARD: Snapshot masternodes reward for each epoch. Empty for disable.
 VERBOSITY: log level from 1 to 5. Here we're using 4 for debug messages.
 ```
 

--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -1,19 +1,5 @@
 #!/bin/sh
 
-# vars from docker env
-# - IDENTITY (default to empty)
-# - PASSWORD (default to empty)
-# - PRIVATE_KEY (default to empty)
-# - BOOTNODES (default to empty)
-# - EXTIP (default to empty)
-# - VERBOSITY (default to 3)
-# - MAXPEERS (default to 25)
-# - SYNC_MODE (default to 'full')
-# - NETWORK_ID (default to '89')
-# - WS_SECRET (default to empty)
-# - NETSTATS_HOST (default to 'netstats-server:3000')
-# - NETSTATS_PORT (default to 'netstats-server:3000')
-
 # constants
 DATA_DIR="data"
 KEYSTORE_DIR="keystore"
@@ -22,14 +8,15 @@ KEYSTORE_DIR="keystore"
 genesisPath=""
 params=""
 accountsCount=$(
-  tomo account list --datadir $DATA_DIR  --keystore $KEYSTORE_DIR \
+  tomo account list --datadir ${DATA_DIR}  --keystore ${KEYSTORE_DIR} \
   2> /dev/null \
   | wc -l
 )
 
 # file to env
-for env in IDENTITY PASSWORD PRIVATE_KEY BOOTNODES WS_SECRET NETSTATS_HOST \
-           NETSTATS_PORT EXTIP SYNC_MODE NETWORK_ID ANNOUNCE_TXS STORE_REWARD DEBUG_MODE MAXPEERS; do
+for env in IDENTITY NETWORK_ID SYNC_MODE RPC_PORT WS_PORT \
+           BOOTNODES EXTIP P2P_PORT NETSTATS_HOST NETSTATS_PORT WS_SECRET \
+           PASSWORD PRIVATE_KEY ANNOUNCE_TXS VERBOSITY ''; do
   file=$(eval echo "\$${env}_FILE")
   if [[ -f $file ]] && [[ ! -z $file ]]; then
     echo "Replacing $env by $file"
@@ -49,46 +36,60 @@ for env in IDENTITY PASSWORD PRIVATE_KEY BOOTNODES WS_SECRET NETSTATS_HOST \
 done
 
 # networkid
-if [[ ! -z $NETWORK_ID ]]; then
-  case $NETWORK_ID in
+if [[ ! -z ${NETWORK_ID} ]]; then
+  case ${NETWORK_ID} in
     88 )
       genesisPath="mainnet.json"
       ;;
     89 )
       genesisPath="testnet.json"
-      params="$params --tomo-testnet --gcmode archive --rpcapi db,eth,net,web3,debug,posv"
-      ;;
-    90 )
-      genesisPath="devnet.json"
+      params="$params --tomo-testnet"
       ;;
     * )
-      echo "network id not supported"
+      params="$params --tomo-testnet"
       ;;
   esac
-  params="$params --networkid $NETWORK_ID"
 fi
 
 # custom genesis path
-if [[ ! -z $GENESIS_PATH ]]; then
-  genesisPath="$GENESIS_PATH"
+if [[ ! -z ${GENESIS_PATH} ]]; then
+  genesisPath="${GENESIS_PATH}"
 fi
 
 # data dir
-if [[ ! -d $DATA_DIR/tomo ]]; then
+if [[ ! -d ${DATA_DIR}/tomo ]]; then
   echo "No blockchain data, creating genesis block."
-  tomo init $genesisPath --datadir $DATA_DIR 2> /dev/null
+  tomo init $genesisPath --datadir ${DATA_DIR} 2> /dev/null
 fi
 
 # identity
-if [[ -z $IDENTITY ]]; then
+if [[ -z ${IDENTITY} ]]; then
   IDENTITY="unnamed_$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)"
+fi
+
+# bootnodes
+if [[ ! -z ${BOOTNODES} ]]; then
+  params="$params --bootnodes ${BOOTNODES}"
+fi
+
+# extip
+if [[ ! -z ${EXTIP} ]]; then
+  params="$params --nat extip:${EXTIP}"
+fi
+
+# netstats
+if [[ ! -z ${WS_SECRET} ]]; then
+  echo "Will report to netstats server ${NETSTATS_HOST}:${NETSTATS_PORT}"
+  params="$params --ethstats ${IDENTITY}:${WS_SECRET}@${NETSTATS_HOST}:${NETSTATS_PORT}"
+else
+  echo "WS_SECRET not set, will not report to netstats server."
 fi
 
 # password file
 if [[ ! -f ./password ]]; then
-  if [[ ! -z $PASSWORD ]]; then
+  if [[ ! -z ${PASSWORD} ]]; then
     echo "Password env is set. Writing into file."
-    echo "$PASSWORD" > ./password
+    echo "${PASSWORD}" > ./password
   else
     echo "No password set (or empty), generating a new one"
     $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32} > password)
@@ -98,24 +99,24 @@ fi
 # private key
 if [[ $accountsCount -le 0 ]]; then
   echo "No accounts found"
-  if [[ ! -z $PRIVATE_KEY ]]; then
+  if [[ ! -z ${PRIVATE_KEY} ]]; then
     echo "Creating account from private key"
-    echo "$PRIVATE_KEY" > ./private_key
+    echo "${PRIVATE_KEY}" > ./private_key
     tomo  account import ./private_key \
-      --datadir $DATA_DIR \
-      --keystore $KEYSTORE_DIR \
+      --datadir ${DATA_DIR} \
+      --keystore ${KEYSTORE_DIR} \
       --password ./password
     rm ./private_key
   else
     echo "Creating new account"
     tomo account new \
-      --datadir $DATA_DIR \
-      --keystore $KEYSTORE_DIR \
+      --datadir ${DATA_DIR} \
+      --keystore ${KEYSTORE_DIR} \
       --password ./password
   fi
 fi
 account=$(
-  tomo account list --datadir $DATA_DIR  --keystore $KEYSTORE_DIR \
+  tomo account list --datadir ${DATA_DIR}  --keystore ${KEYSTORE_DIR} \
   2> /dev/null \
   | head -n 1 \
   | cut -d"{" -f 2 | cut -d"}" -f 1
@@ -123,64 +124,30 @@ account=$(
 echo "Using account $account"
 params="$params --unlock $account"
 
-# bootnodes
-if [[ ! -z $BOOTNODES ]]; then
-  params="$params --bootnodes $BOOTNODES"
-fi
-
-# extip
-if [[ ! -z $EXTIP ]]; then
-  params="$params --nat extip:${EXTIP}"
-fi
-
-# syncmode
-if [[ ! -z $SYNC_MODE ]]; then
-  params="$params --syncmode ${SYNC_MODE}"
-fi
-
-# netstats
-if [[ ! -z $WS_SECRET ]]; then
-  echo "Will report to netstats server ${NETSTATS_HOST}:${NETSTATS_PORT}"
-  params="$params --ethstats ${IDENTITY}:${WS_SECRET}@${NETSTATS_HOST}:${NETSTATS_PORT}"
-else
-  echo "WS_SECRET not set, will not report to netstats server."
-fi
-
 # annonce txs
-if [[ ! -z $ANNOUNCE_TXS ]]; then
+if [[ ! -z ${ANNOUNCE_TXS} ]]; then
   params="$params --announce-txs"
 fi
 
-# store reward
-if [[ ! -z $STORE_REWARD ]]; then
-  params="$params --store-reward"
-fi
-
 # debug mode
-if [[ ! -z $DEBUG_MODE ]]; then
+if [[ ! -z ${DEBUG_MODE} ]]; then
   params="$params --gcmode archive --rpcapi db,eth,net,web3,debug,posv"
 fi
 
-# maxpeers
-if [[ -z $MAXPEERS ]]; then
-  MAXPEERS=25
+# store reward
+if [[ ! -z ${STORE_REWARD} ]]; then
+  params="$params --store-reward"
 fi
 
 # dump
-echo "dump: $IDENTITY $account $BOOTNODES"
+echo "dump: ${IDENTITY} $account ${BOOTNODES}"
 
 set -x
 
-exec tomo $params \
-  --verbosity $VERBOSITY \
-  --datadir $DATA_DIR \
-  --keystore $KEYSTORE_DIR \
-  --identity $IDENTITY \
-  --maxpeers $MAXPEERS \
-  --password ./password \
-  --port 30303 \
-  --txpool.globalqueue 5000 \
-  --txpool.globalslots 5000 \
+exec tomo --identity ${IDENTITY} \
+  --datadir ${DATA_DIR} \
+  --networkid ${NETWORK_ID} \
+  --syncmode ${SYNC_MODE} \
   --rpc \
   --rpccorsdomain "*" \
   --rpcaddr 0.0.0.0 \
@@ -190,7 +157,15 @@ exec tomo $params \
   --wsaddr 0.0.0.0 \
   --wsport 8546 \
   --wsorigins "*" \
+  --port ${P2P_PORT} \
+  --maxpeers ${MAX_PEERS} \
+  --txpool.globalqueue 5000 \
+  --txpool.globalslots 5000 \
   --mine \
+  --keystore ${KEYSTORE_DIR} \
+  --password ./password \
   --gasprice "250000000" \
   --targetgaslimit "84000000" \
+  --verbosity ${VERBOSITY} \
+  ${params} \
   "$@"

--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -14,7 +14,7 @@ accountsCount=$(
 )
 
 # file to env
-for env in IDENTITY NETWORK_ID SYNC_MODE RPC_PORT WS_PORT \
+for env in IDENTITY NETWORK_ID SYNC_MODE \
            BOOTNODES EXTIP P2P_PORT NETSTATS_HOST NETSTATS_PORT WS_SECRET \
            PASSWORD PRIVATE_KEY ANNOUNCE_TXS VERBOSITY ''; do
   file=$(eval echo "\$${env}_FILE")


### PR DESCRIPTION
This update enable node operators to map P2P port to any port in a system, allow running multiple nodes using Docker in a single system.

There is some minor update update in Dockerfile and sh syntax to make remove warning with recent version of Docker.