### PR TITLE
Hotfix: Resolve nil pointer issue

### DIFF
--- a/cmd/tomo/dbcmd.go
+++ b/cmd/tomo/dbcmd.go
@@ -81,18 +81,18 @@ func setupChain(ctx *cli.Context) (ethdb.Database, tomoConfig, *params.ChainConf
 	chainConfig, _, _ := core.SetupGenesisBlock(chainDB, nodeConfig.Eth.Genesis)
 
 	var (
-		vmConfig       = vm.Config{}
-		cacheConfig    = &core.CacheConfig{}
-		tomoXService   *tomox.TomoX
-		lendingService *tomoxlending.Lending
+		vmConfig    = vm.Config{}
+		cacheConfig = &core.CacheConfig{}
 	)
 
 	posvConsensus := posv.New(chainConfig.Posv, chainDB)
+
+	tomoXService := tomox.New(&nodeConfig.TomoX)
 	posvConsensus.GetTomoXService = func() posv.TradingService {
 		return tomoXService
 	}
 	posvConsensus.GetLendingService = func() posv.LendingService {
-		return lendingService
+		return tomoxlending.New(tomoXService)
 	}
 
 	blockchain, err := core.NewBlockChain(chainDB, cacheConfig, chainConfig, posvConsensus, vmConfig)


### PR DESCRIPTION
This fix addresses a nil pointer issue caused by `GetTomoxService` returning a nil pointer. The issue prevented method calls on the tomox object, leading to potential crashes or runtime errors. The root cause was the service not being properly initialized, and this hotfix ensures proper handling to prevent such errors.