### PR TITLE
core/state: Add some state metrics

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -80,7 +80,7 @@ type Trie interface {
 
 	// Commit writes all nodes to the trie's memory database, tracking the internal
 	// and external (for account tries) references.
-	Commit(onleaf trie.LeafCallback) (common.Hash, error)
+	Commit(onleaf trie.LeafCallback) (common.Hash, int, error)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key.

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import "github.com/tomochain/tomochain/metrics"
+
+var (
+	accountUpdatedMeter   = metrics.NewRegisteredMeter("state/update/account", nil)
+	storageUpdatedMeter   = metrics.NewRegisteredMeter("state/update/storage", nil)
+	accountDeletedMeter   = metrics.NewRegisteredMeter("state/delete/account", nil)
+	storageDeletedMeter   = metrics.NewRegisteredMeter("state/delete/storage", nil)
+	accountCommittedMeter = metrics.NewRegisteredMeter("state/commit/account", nil)
+	storageCommittedMeter = metrics.NewRegisteredMeter("state/commit/storage", nil)
+)

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -19,9 +19,10 @@ package light
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/tomochain/tomochain/core/rawdb"
 	"math/big"
 	"time"
+
+	"github.com/tomochain/tomochain/core/rawdb"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/common/bitutil"
@@ -174,7 +175,7 @@ func (c *ChtIndexerBackend) Process(header *types.Header) {
 
 // Commit implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Commit() error {
-	root, err := c.trie.Commit(nil)
+	root, _, err := c.trie.Commit(nil)
 	if err != nil {
 		return err
 	}
@@ -293,7 +294,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 			b.trie.Delete(encKey[:])
 		}
 	}
-	root, err := b.trie.Commit(nil)
+	root, _, err := b.trie.Commit(nil)
 	if err != nil {
 		return err
 	}

--- a/light/trie.go
+++ b/light/trie.go
@@ -119,9 +119,9 @@ func (t *odrTrie) TryDelete(key []byte) error {
 	})
 }
 
-func (t *odrTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
+func (t *odrTrie) Commit(onleaf trie.LeafCallback) (common.Hash, int, error) {
 	if t.trie == nil {
-		return t.id.Root, nil
+		return t.id.Root, 0, nil
 	}
 	return t.trie.Commit(onleaf)
 }

--- a/tomox/tradingstate/database.go
+++ b/tomox/tradingstate/database.go
@@ -67,7 +67,7 @@ type Trie interface {
 	TryGetBestRightKeyAndValue() ([]byte, []byte, error)
 	TryUpdate(key, value []byte) error
 	TryDelete(key []byte) error
-	Commit(onleaf trie.LeafCallback) (common.Hash, error)
+	Commit(onleaf trie.LeafCallback) (common.Hash, int, error)
 	Hash() common.Hash
 	NodeIterator(startKey []byte) trie.NodeIterator
 	GetKey([]byte) []byte // TODO(fjl): remove this when TomoXTrie is removed

--- a/tomox/tradingstate/state_lendingbook.go
+++ b/tomox/tradingstate/state_lendingbook.go
@@ -19,11 +19,12 @@ package tradingstate
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/rlp"
 	"github.com/tomochain/tomochain/trie"
-	"io"
-	"math/big"
 )
 
 type stateLendingBook struct {
@@ -172,7 +173,7 @@ func (self *stateLendingBook) updateRoot(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.trie.Commit(nil)
+	root, _, err := self.trie.Commit(nil)
 	if err == nil {
 		self.data.Root = root
 	}

--- a/tomox/tradingstate/state_liquidationprice.go
+++ b/tomox/tradingstate/state_liquidationprice.go
@@ -18,12 +18,13 @@ package tradingstate
 
 import (
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/rlp"
 	"github.com/tomochain/tomochain/trie"
-	"io"
-	"math/big"
 )
 
 type liquidationPriceState struct {
@@ -130,7 +131,7 @@ func (self *liquidationPriceState) updateRoot(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.trie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.trie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList orderList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil

--- a/tomox/tradingstate/state_orderList.go
+++ b/tomox/tradingstate/state_orderList.go
@@ -167,7 +167,7 @@ func (self *stateOrderList) updateRoot(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.trie.Commit(nil)
+	root, _, err := self.trie.Commit(nil)
 	if err == nil {
 		self.data.Root = root
 	}

--- a/tomox/tradingstate/state_orderbook.go
+++ b/tomox/tradingstate/state_orderbook.go
@@ -18,11 +18,12 @@ package tradingstate
 
 import (
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/rlp"
-	"io"
-	"math/big"
 )
 
 // stateObject represents an Ethereum orderId which is being modified.
@@ -240,7 +241,7 @@ func (self *tradingExchanges) CommitAsksTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.asksTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.asksTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList orderList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil
@@ -299,7 +300,7 @@ func (self *tradingExchanges) CommitBidsTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.bidsTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.bidsTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList orderList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil
@@ -593,7 +594,7 @@ func (self *tradingExchanges) CommitOrdersTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.ordersTrie.Commit(nil)
+	root, _, err := self.ordersTrie.Commit(nil)
 	if err == nil {
 		self.data.OrderRoot = root
 	}
@@ -771,7 +772,7 @@ func (self *tradingExchanges) CommitLiquidationPriceTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.liquidationPriceTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.liquidationPriceTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList orderList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil

--- a/tomox/tradingstate/statedb.go
+++ b/tomox/tradingstate/statedb.go
@@ -584,7 +584,7 @@ func (s *TradingStateDB) Commit() (root common.Hash, err error) {
 		}
 	}
 	// Write trie changes.
-	root, err = s.trie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err = s.trie.Commit(func(leaf []byte, parent common.Hash) error {
 		var exchange tradingExchangeObject
 		if err := rlp.DecodeBytes(leaf, &exchange); err != nil {
 			return nil

--- a/tomox/tradingstate/tomox_trie.go
+++ b/tomox/tradingstate/tomox_trie.go
@@ -18,6 +18,7 @@ package tradingstate
 
 import (
 	"fmt"
+
 	"github.com/tomochain/tomochain/ethdb"
 	"github.com/tomochain/tomochain/trie"
 
@@ -155,7 +156,7 @@ func (t *TomoXTrie) GetKey(shaKey []byte) []byte {
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes
 // from the database.
-func (t *TomoXTrie) Commit(onleaf trie.LeafCallback) (root common.Hash, err error) {
+func (t *TomoXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, int, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		t.trie.Db.Lock.Lock()

--- a/tomoxlending/lendingstate/database.go
+++ b/tomoxlending/lendingstate/database.go
@@ -66,7 +66,7 @@ type Trie interface {
 	TryGetBestRightKeyAndValue() ([]byte, []byte, error)
 	TryUpdate(key, value []byte) error
 	TryDelete(key []byte) error
-	Commit(onleaf trie.LeafCallback) (common.Hash, error)
+	Commit(onleaf trie.LeafCallback) (common.Hash, int, error)
 	Hash() common.Hash
 	NodeIterator(startKey []byte) trie.NodeIterator
 	GetKey([]byte) []byte // TODO(fjl): remove this when TomoXTrie is removed

--- a/tomoxlending/lendingstate/state_itemList.go
+++ b/tomoxlending/lendingstate/state_itemList.go
@@ -19,10 +19,11 @@ package lendingstate
 import (
 	"bytes"
 	"fmt"
-	"github.com/tomochain/tomochain/common"
-	"github.com/tomochain/tomochain/rlp"
 	"io"
 	"math/big"
+
+	"github.com/tomochain/tomochain/common"
+	"github.com/tomochain/tomochain/rlp"
 )
 
 type itemListState struct {
@@ -151,7 +152,7 @@ func (self *itemListState) updateRoot(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.trie.Commit(nil)
+	root, _, err := self.trie.Commit(nil)
 	if err == nil {
 		self.data.Root = root
 	}

--- a/tomoxlending/lendingstate/state_lendingbook.go
+++ b/tomoxlending/lendingstate/state_lendingbook.go
@@ -18,11 +18,12 @@ package lendingstate
 
 import (
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/log"
 	"github.com/tomochain/tomochain/rlp"
-	"io"
-	"math/big"
 )
 
 type lendingExchangeState struct {
@@ -181,8 +182,10 @@ func (self *lendingExchangeState) getLiquidationTimeTrie(db Database) Trie {
 	return self.liquidationTimeTrie
 }
 
-/**
-  Get State
+/*
+*
+
+	Get State
 */
 func (self *lendingExchangeState) getBorrowingOrderList(db Database, rate common.Hash) (stateOrderList *itemListState) {
 	// Prefer 'live' objects.
@@ -299,8 +302,10 @@ func (self *lendingExchangeState) getLendingTrade(db Database, tradeId common.Ha
 	return obj
 }
 
-/**
-  Update Trie
+/*
+*
+
+	Update Trie
 */
 func (self *lendingExchangeState) updateLendingTimeTrie(db Database) Trie {
 	tr := self.getLendingItemTrie(db)
@@ -431,7 +436,7 @@ func (self *lendingExchangeState) CommitLendingItemTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.lendingItemTrie.Commit(nil)
+	root, _, err := self.lendingItemTrie.Commit(nil)
 	if err == nil {
 		self.data.LendingItemRoot = root
 	}
@@ -443,7 +448,7 @@ func (self *lendingExchangeState) CommitLendingTradeTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.lendingTradeTrie.Commit(nil)
+	root, _, err := self.lendingTradeTrie.Commit(nil)
 	if err == nil {
 		self.data.LendingTradeRoot = root
 	}
@@ -455,7 +460,7 @@ func (self *lendingExchangeState) CommitInvestingTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.investingTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.investingTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList itemList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil
@@ -476,7 +481,7 @@ func (self *lendingExchangeState) CommitBorrowingTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.borrowingTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.borrowingTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList itemList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil
@@ -497,7 +502,7 @@ func (self *lendingExchangeState) CommitLiquidationTimeTrie(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.liquidationTimeTrie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err := self.liquidationTimeTrie.Commit(func(leaf []byte, parent common.Hash) error {
 		var orderList itemList
 		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
 			return nil
@@ -513,8 +518,9 @@ func (self *lendingExchangeState) CommitLiquidationTimeTrie(db Database) error {
 	return err
 }
 
-/**
-  Get Trie Data
+/*
+*
+Get Trie Data
 */
 func (self *lendingExchangeState) getBestInvestingInterest(db Database) common.Hash {
 	trie := self.getInvestingTrie(db)

--- a/tomoxlending/lendingstate/state_liquidationtime.go
+++ b/tomoxlending/lendingstate/state_liquidationtime.go
@@ -19,11 +19,12 @@ package lendingstate
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/rlp"
 	"github.com/tomochain/tomochain/trie"
-	"io"
-	"math/big"
 )
 
 type liquidationTimeState struct {
@@ -170,7 +171,7 @@ func (self *liquidationTimeState) updateRoot(db Database) error {
 	if self.dbErr != nil {
 		return self.dbErr
 	}
-	root, err := self.trie.Commit(nil)
+	root, _, err := self.trie.Commit(nil)
 	if err == nil {
 		self.data.Root = root
 	}

--- a/tomoxlending/lendingstate/statedb.go
+++ b/tomoxlending/lendingstate/statedb.go
@@ -573,7 +573,7 @@ func (s *LendingStateDB) Commit() (root common.Hash, err error) {
 		}
 	}
 	// Write trie changes.
-	root, err = s.trie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, _, err = s.trie.Commit(func(leaf []byte, parent common.Hash) error {
 		var exchange lendingObject
 		if err := rlp.DecodeBytes(leaf, &exchange); err != nil {
 			return nil

--- a/tomoxlending/lendingstate/tomox_trie.go
+++ b/tomoxlending/lendingstate/tomox_trie.go
@@ -18,6 +18,7 @@ package lendingstate
 
 import (
 	"fmt"
+
 	"github.com/tomochain/tomochain/ethdb"
 	"github.com/tomochain/tomochain/trie"
 
@@ -151,7 +152,7 @@ func (t *TomoXTrie) GetKey(shaKey []byte) []byte {
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes
 // from the database.
-func (t *TomoXTrie) Commit(onleaf trie.LeafCallback) (root common.Hash, err error) {
+func (t *TomoXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, int, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		t.trie.Db.Lock.Lock()

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -390,7 +390,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	for _, val := range testdata1 {
 		ctr.Update([]byte(val.k), []byte(val.v))
 	}
-	root, _ := ctr.Commit(nil)
+	root, _, _ := ctr.Commit(nil)
 	if !memonly {
 		triedb.Commit(root, true)
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -139,7 +139,7 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes
 // from the database.
-func (t *SecureTrie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
+func (t *SecureTrie) Commit(onleaf LeafCallback) (common.Hash, int, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		t.trie.Db.Lock.Lock()

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -582,12 +582,12 @@ func (t *Trie) Hash() common.Hash {
 
 // Commit writes all nodes to the trie's memory database, tracking the internal
 // and external (for account tries) references.
-func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
+func (t *Trie) Commit(onleaf LeafCallback) (common.Hash, int, error) {
 	if t.Db == nil {
 		panic("commit called on trie with nil database")
 	}
 	if t.root == nil {
-		return emptyRoot, nil
+		return emptyRoot, 0, nil
 	}
 	rootHash := t.Hash()
 	h := newCommitter()
@@ -596,7 +596,7 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 	// up goroutines. This can happen e.g. if we load a trie for reading storage
 	// values, but don't write to it.
 	if !h.commitNeeded(t.root) {
-		return rootHash, nil
+		return rootHash, 0, nil
 	}
 	var wg sync.WaitGroup
 	if onleaf != nil {
@@ -608,8 +608,8 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 			h.commitLoop(t.Db)
 		}()
 	}
-	var newRoot HashNode
-	newRoot, err = h.Commit(t.root, t.Db)
+
+	newRoot, committed, err := h.Commit(t.root, t.Db)
 	if onleaf != nil {
 		// The leafch is created in newCommitter if there was an onleaf callback
 		// provided. The commitLoop only _reads_ from it, and the commit
@@ -619,10 +619,10 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 		wg.Wait()
 	}
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, 0, err
 	}
 	t.root = newRoot
-	return rootHash, nil
+	return rootHash, committed, nil
 }
 
 // hashRoot calculates the root hash of the given trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -86,7 +86,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	trie, _ := New(common.Hash{}, triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, _ := trie.Commit(nil)
+	root, _, _ := trie.Commit(nil)
 	if !memonly {
 		triedb.Commit(root, true)
 	}
@@ -168,7 +168,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, err := trie.Commit(nil)
+	root, _, err := trie.Commit(nil)
 	if err != nil {
 		t.Fatalf("commit error: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	exp, err := trie.Commit(nil)
+	exp, _, err := trie.Commit(nil)
 	if err != nil {
 		t.Fatalf("commit error: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, err := trie2.Commit(nil)
+	hash, _, err := trie2.Commit(nil)
 	if err != nil {
 		t.Fatalf("commit error: %v", err)
 	}
@@ -425,11 +425,11 @@ func runRandTest(rt randTest) bool {
 				rt[i].err = fmt.Errorf("mismatch for key 0x%x, got 0x%x want 0x%x", step.key, v, want)
 			}
 		case opCommit:
-			_, rt[i].err = tr.Commit(nil)
+			_, _, rt[i].err = tr.Commit(nil)
 		case opHash:
 			tr.Hash()
 		case opReset:
-			hash, err := tr.Commit(nil)
+			hash, _, err := tr.Commit(nil)
 			if err != nil {
 				rt[i].err = err
 				return false
@@ -630,7 +630,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _ = trie.Commit(nil)
+	root, _, _ = trie.Commit(nil)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}


### PR DESCRIPTION
This pull request introduces several updates to the `core/state` and `tomox/tradingstate` packages, focusing on enhancing the `Commit` method to return an additional integer value representing the number of committed nodes. Additionally, it includes various code refactorings and improvements to metrics tracking.

### Updates to `core/state` package:
* **Enhanced `Commit` method**: Modified the `Commit` method in multiple files to return an additional integer value indicating the number of committed nodes. (`core/state/database.go`, `core/state/state_object.go`, `core/state/statedb.go`, `light/postprocess.go`, `light/trie.go`) [[1]](diffhunk://#diff-2002ca9f189ebd4dbe9ec777405505525bb4a67db44536243e615f66d85426d2L83-R83) [[2]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606L275-R292) [[3]](diffhunk://#diff-c3757dc9e9d868f63bc84a0cc67159c1d5c22cc5d8c9468757098f0492e0658cR656-R690) Ff568cf3L175R175, [[4]](diffhunk://#diff-e788643145983dfa6baad1bce193b4898cfc9d3ce579f36313a5328e33274751L122-R124)
* **Metrics tracking**: Introduced new metrics to track account and storage updates, deletions, and commits. (`core/state/metrics.go`, `core/state/state_object.go`, `core/state/statedb.go`) [[1]](diffhunk://#diff-dde3acd9bd4b958562beeea7a098c558de70469e2e2d3ab6720ed74c0bc3d733R1-R28) [[2]](diffhunk://#diff-493fcc97ac5eefa37eef088731c482655afbae6c1ebaead72a88b7746897c606R252-R258) [[3]](diffhunk://#diff-c3757dc9e9d868f63bc84a0cc67159c1d5c22cc5d8c9468757098f0492e0658cR591-R595)

```
	accountUpdatedMeter   = metrics.NewRegisteredMeter("state/update/account", nil)
	storageUpdatedMeter   = metrics.NewRegisteredMeter("state/update/storage", nil)
	accountDeletedMeter   = metrics.NewRegisteredMeter("state/delete/account", nil)
	storageDeletedMeter   = metrics.NewRegisteredMeter("state/delete/storage", nil)
	accountCommittedMeter = metrics.NewRegisteredMeter("state/commit/account", nil)
	storageCommittedMeter = metrics.NewRegisteredMeter("state/commit/storage", nil)
```
```
# TYPE state_update_account gauge
state_update_account 7298

# TYPE state_update_storage gauge
state_update_storage 4004

# TYPE state_delete_account gauge
state_delete_account 2156

# TYPE state_delete_storage gauge
state_delete_storage 0

# TYPE state_commit_account gauge
state_commit_account 2405

# TYPE state_commit_storage gauge
state_commit_storage 10262
```

### Updates to `tomox/tradingstate` package:
* **Enhanced `Commit` method**: Updated the `Commit` method across various files to return an additional integer value for the number of committed nodes. (`tomox/tradingstate/database.go`, `tomox/tradingstate/state_lendingbook.go`, `tomox/tradingstate/state_liquidationprice.go`, `tomox/tradingstate/state_orderList.go`, `tomox/tradingstate/state_orderbook.go`, `tomox/tradingstate/statedb.go`, `tomox/tradingstate/tomox_trie.go`) [[1]](diffhunk://#diff-523271d523c27a6998866e004eff6ce23fc4f60d59cf1f159d4ed841f180d66eL70-R70) [[2]](diffhunk://#diff-22b957ea3142390fb54fa6cb17f02fe02173c735acd66a124cb9ac60cb13632eL175-R176) [[3]](diffhunk://#diff-af132865a537abc7aa8e35592fcfb42f8a23322d2b6fb75f656e59dfce6950fcL133-R134) [[4]](diffhunk://#diff-4d3ed37f67d171b24536f3f710c82b7e8b73746f22cd9ae2b7fb96e7e8124aa4L170-R170) [[5]](diffhunk://#diff-c7987fa8e60579008cb7b49445496551540fe86fb4d0c4c71c644659d53c4e6cL243-R244) [[6]](diffhunk://#diff-ad97e207bd679ed95148aed1e1acd668bafc643cc04e6a82dfb74d0dc0747383L587-R587) [[7]](diffhunk://#diff-7969196eb0d60cacd8aa806d881572f3010ee883a6aa15288353754cb067dd5fL158-R159)
* **Code refactoring**: Improved code readability by reordering imports and adjusting comments. (`tomox/tradingstate/state_lendingbook.go`, `tomox/tradingstate/state_liquidationprice.go`, `tomox/tradingstate/state_itemList.go`, `tomoxlending/lendingstate/state_lendingbook.go`) [[1]](diffhunk://#diff-22b957ea3142390fb54fa6cb17f02fe02173c735acd66a124cb9ac60cb13632eR22-L26) [[2]](diffhunk://#diff-af132865a537abc7aa8e35592fcfb42f8a23322d2b6fb75f656e59dfce6950fcR21-L26) [[3]](diffhunk://#diff-25f1d89b8666b26ef4edef703d462d85103835133ba78f66651d144962fb9b35L22-R26) [[4]](diffhunk://#diff-1ad3fa4bccd7b27fe96a7d904d2be4e70df2b79d4bd0022c5d76f6b2c8b53e53R21-L25)

These changes collectively improve the functionality and maintainability of the codebase by providing more detailed commit information and enhancing metrics tracking.

### Reference:
- https://github.com/ethereum/go-ethereum/pull/23433