### PR TITLE
core/txpool: add some txpool metrics 

### DIFF
--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -671,7 +671,7 @@ func (pool *LendingPool) add(tx *types.LendingTransaction, local bool) (bool, er
 	// If the transaction fails basic validation, discard it
 	if err := pool.validateTx(tx, local); err != nil {
 		log.Debug("Discarding invalid lending transaction", "hash", hash, "userAddress", tx.UserAddress, "status", tx.Status, "err", err)
-		invalidTxCounter.Inc(1)
+		invalidTxMeter.Mark(1)
 		return false, err
 	}
 	from, _ := types.LendingSender(pool.signer, tx) // already validated
@@ -685,12 +685,12 @@ func (pool *LendingPool) add(tx *types.LendingTransaction, local bool) (bool, er
 	if list := pool.pending[from]; list != nil && list.Overlaps(tx) {
 		inserted, old := list.Add(tx)
 		if !inserted {
-			pendingDiscardCounter.Inc(1)
+			pendingDiscardMeter.Mark(1)
 			return false, ErrPendingNonceTooLow
 		}
 		if old != nil {
 			delete(pool.all, old.Hash())
-			pendingReplaceCounter.Inc(1)
+			pendingReplaceMeter.Mark(1)
 		}
 		pool.all[tx.Hash()] = tx
 		pool.journalTx(from, tx)
@@ -726,13 +726,13 @@ func (pool *LendingPool) enqueueTx(hash common.Hash, tx *types.LendingTransactio
 	inserted, old := pool.queue[from].Add(tx)
 	if !inserted {
 		// An older transaction was better, discard this
-		queuedDiscardCounter.Inc(1)
+		queuedDiscardMeter.Mark(1)
 		return false, ErrPendingNonceTooLow
 	}
 	// Discard any previous transaction and mark this
 	if old != nil {
 		delete(pool.all, old.Hash())
-		queuedReplaceCounter.Inc(1)
+		queuedReplaceMeter.Mark(1)
 	}
 	pool.all[hash] = tx
 	return old != nil, nil
@@ -764,13 +764,13 @@ func (pool *LendingPool) promoteTx(addr common.Address, hash common.Hash, tx *ty
 	if !inserted {
 		// An older transaction was better, discard this
 		delete(pool.all, hash)
-		pendingDiscardCounter.Inc(1)
+		pendingDiscardMeter.Mark(1)
 		return
 	}
 	// Otherwise discard any previous transaction and mark this
 	if old != nil {
 		delete(pool.all, old.Hash())
-		pendingReplaceCounter.Inc(1)
+		pendingReplaceMeter.Mark(1)
 	}
 	// Failsafe to work around direct pending inserts (tests)
 	if pool.all[hash] == nil {
@@ -976,13 +976,14 @@ func (pool *LendingPool) promoteExecutables(accounts []common.Address) {
 		}
 		// Drop all transactions over the allowed limit
 		if !pool.locals.contains(addr) {
-			for _, tx := range list.Cap(int(pool.config.AccountQueue)) {
+			caps := list.Cap(int(pool.config.AccountQueue))
+			for _, tx := range caps {
 				hash := tx.Hash()
 				delete(pool.all, hash)
 
-				queuedRateLimitCounter.Inc(1)
 				log.Trace("Removed cap-exceeding queued transaction", "hash", hash)
 			}
+			queuedRateLimitMeter.Mark(int64(len(caps)))
 		}
 		// Delete the entire queue entry if it became empty.
 		if list.Empty() {
@@ -1056,7 +1057,7 @@ func (pool *LendingPool) promoteExecutables(accounts []common.Address) {
 				}
 			}
 		}
-		pendingRateLimitCounter.Inc(int64(pendingBeforeCap - pending))
+		pendingRateLimitMeter.Mark(int64(pendingBeforeCap - pending))
 	}
 	// If we've queued more transactions than the hard limit, drop oldest ones
 	queued := uint64(0)
@@ -1086,7 +1087,7 @@ func (pool *LendingPool) promoteExecutables(accounts []common.Address) {
 					pool.removeTx(tx.Hash())
 				}
 				drop -= size
-				queuedRateLimitCounter.Inc(int64(size))
+				queuedRateLimitMeter.Mark(int64(size))
 				continue
 			}
 			// Otherwise drop only last few transactions
@@ -1094,7 +1095,7 @@ func (pool *LendingPool) promoteExecutables(accounts []common.Address) {
 			for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
 				pool.removeTx(txs[i].Hash())
 				drop--
-				queuedRateLimitCounter.Inc(1)
+				queuedRateLimitMeter.Mark(1)
 			}
 		}
 	}

--- a/core/order_pool.go
+++ b/core/order_pool.go
@@ -579,7 +579,7 @@ func (pool *OrderPool) add(tx *types.OrderTransaction, local bool) (bool, error)
 	// If the transaction fails basic validation, discard it
 	if err := pool.validateTx(tx, local); err != nil {
 		log.Debug("Discarding invalid order transaction", "hash", hash, "userAddress", tx.UserAddress().Hex(), "status", tx.Status, "err", err)
-		invalidTxCounter.Inc(1)
+		invalidTxMeter.Mark(1)
 		return false, err
 	}
 	from, _ := types.OrderSender(pool.signer, tx) // already validated
@@ -593,12 +593,12 @@ func (pool *OrderPool) add(tx *types.OrderTransaction, local bool) (bool, error)
 	if list := pool.pending[from]; list != nil && list.Overlaps(tx) {
 		inserted, old := list.Add(tx)
 		if !inserted {
-			pendingDiscardCounter.Inc(1)
+			pendingDiscardMeter.Mark(1)
 			return false, ErrPendingNonceTooLow
 		}
 		if old != nil {
 			delete(pool.all, old.Hash())
-			pendingReplaceCounter.Inc(1)
+			pendingReplaceMeter.Mark(1)
 		}
 		pool.all[tx.Hash()] = tx
 		pool.journalTx(from, tx)
@@ -636,13 +636,13 @@ func (pool *OrderPool) enqueueTx(hash common.Hash, tx *types.OrderTransaction) (
 	inserted, old := pool.queue[from].Add(tx)
 	if !inserted {
 		// An older transaction was better, discard this
-		queuedDiscardCounter.Inc(1)
+		queuedDiscardMeter.Mark(1)
 		return false, ErrPendingNonceTooLow
 	}
 	// Discard any previous transaction and mark this
 	if old != nil {
 		delete(pool.all, old.Hash())
-		queuedReplaceCounter.Inc(1)
+		queuedReplaceMeter.Mark(1)
 	}
 	pool.all[hash] = tx
 	return old != nil, nil
@@ -675,13 +675,13 @@ func (pool *OrderPool) promoteTx(addr common.Address, hash common.Hash, tx *type
 	if !inserted {
 		// An older transaction was better, discard this
 		delete(pool.all, hash)
-		pendingDiscardCounter.Inc(1)
+		pendingDiscardMeter.Mark(1)
 		return
 	}
 	// Otherwise discard any previous transaction and mark this
 	if old != nil {
 		delete(pool.all, old.Hash())
-		pendingReplaceCounter.Inc(1)
+		pendingReplaceMeter.Mark(1)
 	}
 	// Failsafe to work around direct pending inserts (tests)
 	if pool.all[hash] == nil {
@@ -890,13 +890,14 @@ func (pool *OrderPool) promoteExecutables(accounts []common.Address) {
 		}
 		// Drop all transactions over the allowed limit
 		if !pool.locals.contains(addr) {
-			for _, tx := range list.Cap(int(pool.config.AccountQueue)) {
+			caps := list.Cap(int(pool.config.AccountQueue))
+			for _, tx := range caps {
 				hash := tx.Hash()
 				delete(pool.all, hash)
 
-				queuedRateLimitCounter.Inc(1)
 				log.Debug("Removed cap-exceeding queued transaction", "addr", tx.UserAddress().Hex(), "nonce", tx.Nonce(), "ohash", tx.OrderHash().Hex(), "status", tx.Status(), "orderid", tx.OrderID())
 			}
+			queuedRateLimitMeter.Mark(int64(len(caps)))
 		}
 		// Delete the entire queue entry if it became empty.
 		if list.Empty() {
@@ -971,7 +972,7 @@ func (pool *OrderPool) promoteExecutables(accounts []common.Address) {
 				}
 			}
 		}
-		pendingRateLimitCounter.Inc(int64(pendingBeforeCap - pending))
+		pendingRateLimitMeter.Mark(int64(pendingBeforeCap - pending))
 	}
 	// If we've queued more transactions than the hard limit, drop oldest ones
 	queued := uint64(0)
@@ -1001,7 +1002,7 @@ func (pool *OrderPool) promoteExecutables(accounts []common.Address) {
 					pool.removeTx(tx.Hash())
 				}
 				drop -= size
-				queuedRateLimitCounter.Inc(int64(size))
+				queuedRateLimitMeter.Mark(int64(size))
 				continue
 			}
 			// Otherwise drop only last few transactions
@@ -1009,7 +1010,7 @@ func (pool *OrderPool) promoteExecutables(accounts []common.Address) {
 			for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
 				pool.removeTx(txs[i].Hash())
 				drop--
-				queuedRateLimitCounter.Inc(1)
+				queuedRateLimitMeter.Mark(1)
 			}
 		}
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -109,7 +109,7 @@ var (
 	queuedNofundsMeter   = metrics.NewRegisteredMeter("txpool/queued/nofunds", nil)   // Dropped due to out-of-funds
 
 	// General tx metrics
-	validMeter         = metrics.NewRegisteredMeter("txpool/valid", nil)
+	validTxMeter       = metrics.NewRegisteredMeter("txpool/valid", nil)
 	invalidTxMeter     = metrics.NewRegisteredMeter("txpool/invalid", nil)
 	underpricedTxMeter = metrics.NewRegisteredMeter("txpool/underpriced", nil)
 
@@ -941,7 +941,7 @@ func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	validMeter.Mark(1)
+	validTxMeter.Mark(1)
 
 	// If we added a new transaction, run promotion checks and return
 	if !replace {
@@ -975,7 +975,7 @@ func (pool *TxPool) addTxsLocked(txs []*types.Transaction, local bool) []error {
 			}
 		}
 	}
-	validMeter.Mark(int64(len(dirty)))
+	validTxMeter.Mark(int64(len(dirty)))
 
 	// Only reprocess the internal state if something was actually added
 	if len(dirty) > 0 {
@@ -1306,7 +1306,7 @@ func (pool *TxPool) demoteUnexecutables() {
 				log.Warn("Demoting invalidated transaction", "hash", hash)
 				pool.enqueueTx(hash, tx)
 			}
-			pendingGauge.Inc(int64(len(gapped)))
+			pendingGauge.Dec(int64(len(gapped)))
 		}
 		// Delete the entire queue entry if it became empty.
 		if list.Empty() {

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -6,6 +6,8 @@ import "sync/atomic"
 type Gauge interface {
 	Snapshot() Gauge
 	Update(int64)
+	Dec(int64)
+	Inc(int64)
 	Value() int64
 }
 
@@ -65,6 +67,16 @@ func (GaugeSnapshot) Update(int64) {
 	panic("Update called on a GaugeSnapshot")
 }
 
+// Dec panics.
+func (GaugeSnapshot) Dec(int64) {
+	panic("Dec called on a GaugeSnapshot")
+}
+
+// Inc panics.
+func (GaugeSnapshot) Inc(int64) {
+	panic("Inc called on a GaugeSnapshot")
+}
+
 // Value returns the value at the time the snapshot was taken.
 func (g GaugeSnapshot) Value() int64 { return int64(g) }
 
@@ -76,6 +88,12 @@ func (NilGauge) Snapshot() Gauge { return NilGauge{} }
 
 // Update is a no-op.
 func (NilGauge) Update(v int64) {}
+
+// Dec is a no-op.
+func (NilGauge) Dec(i int64) {}
+
+// Inc is a no-op.
+func (NilGauge) Inc(i int64) {}
 
 // Value is a no-op.
 func (NilGauge) Value() int64 { return 0 }
@@ -94,6 +112,16 @@ func (g *StandardGauge) Snapshot() Gauge {
 // Update updates the gauge's value.
 func (g *StandardGauge) Update(v int64) {
 	atomic.StoreInt64(&g.value, v)
+}
+
+// Dec decrements the gauge's current value by the given amount.
+func (g *StandardGauge) Dec(i int64) {
+	atomic.AddInt64(&g.value, -i)
+}
+
+// Inc increments the gauge's current value by the given amount.
+func (g *StandardGauge) Inc(i int64) {
+	atomic.AddInt64(&g.value, i)
 }
 
 // Value returns the gauge's current value.
@@ -117,4 +145,14 @@ func (g FunctionalGauge) Snapshot() Gauge { return GaugeSnapshot(g.Value()) }
 // Update panics.
 func (FunctionalGauge) Update(int64) {
 	panic("Update called on a FunctionalGauge")
+}
+
+// Dec panics.
+func (FunctionalGauge) Dec(int64) {
+	panic("Dec called on a FunctionalGauge")
+}
+
+// Inc panics.
+func (FunctionalGauge) Inc(int64) {
+	panic("Inc called on a FunctionalGauge")
 }


### PR DESCRIPTION
This pull request includes several changes to replace the use of counters with meters for transaction metrics in the lending pool, order pool, and transaction pool. The most important changes include modifying various methods to use meters instead of counters and updating the metric definitions.

### Metrics Update:

* [`core/tx_pool.go`](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L100-R118): Replaced counters with meters for various transaction metrics, including `pendingDiscardMeter`, `pendingReplaceMeter`, `queuedDiscardMeter`, and `invalidTxMeter`. Added new gauges for `pendingGauge`, `queuedGauge`, and `localGauge`. [[1]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L100-R118) [[2]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L713-R718) [[3]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L726-R738) [[4]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L742-R754) [[5]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932R776-R778) [[6]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L789-R807) [[7]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L831-R853) [[8]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L867-R884) [[9]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932R944-R945) [[10]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932R978-R979) [[11]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932R1034-R1037) [[12]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932R1054-R1055) [[13]](diffhunk://#diff-725c968cf4066e1624f322938bfe5ed8389186662b85229d61878c591f879932L1062-R1090)

```
# TYPE txpool_invalid gauge
txpool_invalid 19

# TYPE txpool_local gauge
txpool_local 0

# TYPE txpool_pending gauge
txpool_pending 6

# TYPE txpool_pending_discard gauge
txpool_pending_discard 0

# TYPE txpool_pending_nofunds gauge
txpool_pending_nofunds 0

# TYPE txpool_pending_ratelimit gauge
txpool_pending_ratelimit 0

# TYPE txpool_pending_replace gauge
txpool_pending_replace 0

# TYPE txpool_queued gauge
txpool_queued 0

# TYPE txpool_queued_discard gauge
txpool_queued_discard 0

# TYPE txpool_queued_nofunds gauge
txpool_queued_nofunds 0

# TYPE txpool_queued_ratelimit gauge
txpool_queued_ratelimit 0

# TYPE txpool_queued_replace gauge
txpool_queued_replace 0

# TYPE txpool_underpriced gauge
txpool_underpriced 0

# TYPE txpool_valid gauge
txpool_valid 7763

```

* [`core/lending_pool.go`](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L674-R674): Updated methods to use meters instead of counters for tracking invalid, pending, and queued transactions. [[1]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L674-R674) [[2]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L688-R693) [[3]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L729-R735) [[4]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L767-R773) [[5]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L979-R986) [[6]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L1059-R1060) [[7]](diffhunk://#diff-b07f78fee3b8ae7d7562e647c8bad18ef3685980f71faa1373fbd69dd7f5cd05L1089-R1098)

* [`core/order_pool.go`](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL582-R582): Modified methods to replace counters with meters for invalid, pending, and queued transactions. [[1]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL582-R582) [[2]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL596-R601) [[3]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL639-R645) [[4]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL678-R684) [[5]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL893-R900) [[6]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL974-R975) [[7]](diffhunk://#diff-d9476b467420eff786c106dc0504a8a8c45500a602f86680e8a775e99b26bceeL1004-R1013)

### Reference: 
- https://github.com/ethereum/go-ethereum/pull/19692
- https://github.com/ethereum/go-ethereum/pull/20047
- https://github.com/ethereum/go-ethereum/pull/20081