### PR TITLE
rpc: add new metrics for rpc module

### DIFF
--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -6,6 +6,8 @@ import "sync/atomic"
 type Gauge interface {
 	Snapshot() Gauge
 	Update(int64)
+	Dec(int64)
+	Inc(int64)
 	Value() int64
 }
 
@@ -65,6 +67,16 @@ func (GaugeSnapshot) Update(int64) {
 	panic("Update called on a GaugeSnapshot")
 }
 
+// Dec panics.
+func (GaugeSnapshot) Dec(int64) {
+	panic("Dec called on a GaugeSnapshot")
+}
+
+// Inc panics.
+func (GaugeSnapshot) Inc(int64) {
+	panic("Inc called on a GaugeSnapshot")
+}
+
 // Value returns the value at the time the snapshot was taken.
 func (g GaugeSnapshot) Value() int64 { return int64(g) }
 
@@ -76,6 +88,12 @@ func (NilGauge) Snapshot() Gauge { return NilGauge{} }
 
 // Update is a no-op.
 func (NilGauge) Update(v int64) {}
+
+// Dec is a no-op.
+func (NilGauge) Dec(i int64) {}
+
+// Inc is a no-op.
+func (NilGauge) Inc(i int64) {}
 
 // Value is a no-op.
 func (NilGauge) Value() int64 { return 0 }
@@ -94,6 +112,16 @@ func (g *StandardGauge) Snapshot() Gauge {
 // Update updates the gauge's value.
 func (g *StandardGauge) Update(v int64) {
 	atomic.StoreInt64(&g.value, v)
+}
+
+// Dec decrements the gauge's current value by the given amount.
+func (g *StandardGauge) Dec(i int64) {
+	atomic.AddInt64(&g.value, -i)
+}
+
+// Inc increments the gauge's current value by the given amount.
+func (g *StandardGauge) Inc(i int64) {
+	atomic.AddInt64(&g.value, i)
 }
 
 // Value returns the gauge's current value.
@@ -117,4 +145,14 @@ func (g FunctionalGauge) Snapshot() Gauge { return GaugeSnapshot(g.Value()) }
 // Update panics.
 func (FunctionalGauge) Update(int64) {
 	panic("Update called on a FunctionalGauge")
+}
+
+// Dec panics.
+func (FunctionalGauge) Dec(int64) {
+	panic("Dec called on a FunctionalGauge")
+}
+
+// Inc panics.
+func (FunctionalGauge) Inc(int64) {
+	panic("Inc called on a FunctionalGauge")
 }

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/tomochain/tomochain/metrics"
+)
+
+var (
+	rpcRequestGauge        = metrics.NewRegisteredGauge("rpc/requests", nil)
+	successfulRequestGauge = metrics.NewRegisteredGauge("rpc/success", nil)
+	failedRequestGauge     = metrics.NewRegisteredGauge("rpc/failure", nil)
+	rpcServingTimer        = metrics.NewRegisteredTimer("rpc/duration/all", nil)
+)
+
+func newRPCServingTimer(method string, valid bool) metrics.Timer {
+	flag := "success"
+	if !valid {
+		flag = "failure"
+	}
+	m := fmt.Sprintf("rpc/duration/%s/%s", method, flag)
+	return metrics.GetOrRegisterTimer(m, nil)
+}


### PR DESCRIPTION
This pull request includes significant changes to the `metrics/gauge.go` file to add increment and decrement functionalities to the `Gauge` interface and its implementations. Additionally, it introduces new metrics and timing functionalities in the `rpc` package.

### Introduction of new metrics and timing functionalities in `rpc` package:

* Added new gauges for tracking RPC requests, successes, and failures, as well as timers for measuring RPC method call durations. (`rpc/metrics.go`, [rpc/metrics.goR1-R39](diffhunk://#diff-5aa7307e4ba4ff47b67901180be3d5b6aeba52ccc1d88b1ba23117f6487e7abcR1-R39))
```	
rpcRequestGauge        = metrics.NewRegisteredGauge("rpc/requests", nil)
successfulRequestGauge = metrics.NewRegisteredGauge("rpc/success", nil)
failedRequestGauge     = metrics.NewRegisteredGauge("rpc/failure", nil)
rpcServingTimer        = metrics.NewRegisteredTimer("rpc/duration/all", nil)
```
* Imported the `time` package to support timing functionalities. (`rpc/server.go`, [rpc/server.goR27](diffhunk://#diff-c3e4025e60adc4bc84836920c71501cd8f07d96acc76fe9f8f5b32bc256b89e9R27))
* Corrected a typo in the comment for `OptionSubscriptions`. (`rpc/server.go`, [rpc/server.goL41-R42](diffhunk://#diff-c3e4025e60adc4bc84836920c71501cd8f07d96acc76fe9f8f5b32bc256b89e9L41-R42))
* Incremented the `rpcRequestGauge` at the start of the `handle` function and added timing logic for RPC method calls. (`rpc/server.go`, [[1]](diffhunk://#diff-c3e4025e60adc4bc84836920c71501cd8f07d96acc76fe9f8f5b32bc256b89e9R303-R308) [[2]](diffhunk://#diff-c3e4025e60adc4bc84836920c71501cd8f07d96acc76fe9f8f5b32bc256b89e9R320-R343)

### New `rpc` metrics:
```
# TYPE rpc_duration_Version_success_count counter
rpc_duration_Version_success_count 210

# TYPE rpc_duration_Version_success summary
rpc_duration_Version_success {quantile="0.5"} 24145.5
rpc_duration_Version_success {quantile="0.75"} 54249.75
rpc_duration_Version_success {quantile="0.95"} 693722.5499999997
rpc_duration_Version_success {quantile="0.99"} 2.212035999999999e+06
rpc_duration_Version_success {quantile="0.999"} 2.692416e+06
rpc_duration_Version_success {quantile="0.9999"} 2.692416e+06

# TYPE rpc_duration_all_count counter
rpc_duration_all_count 781

# TYPE rpc_duration_all summary
rpc_duration_all {quantile="0.5"} 103500
rpc_duration_all {quantile="0.75"} 272021
rpc_duration_all {quantile="0.95"} 1.2166131e+06
rpc_duration_all {quantile="0.99"} 5.447050559999951e+06
rpc_duration_all {quantile="0.999"} 1.8066041e+07
rpc_duration_all {quantile="0.9999"} 1.8066041e+07

# TYPE rpc_failure gauge
rpc_failure 0

# TYPE rpc_requests gauge
rpc_requests 781

# TYPE rpc_success gauge
rpc_success 781
```
### Reference: 
- https://github.com/ethereum/go-ethereum/pull/20847