### PR TITLE
p2p: Add metrics for tracking p2p modules

### DIFF
--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -6,6 +6,8 @@ import "sync/atomic"
 type Gauge interface {
 	Snapshot() Gauge
 	Update(int64)
+	Dec(int64)
+	Inc(int64)
 	Value() int64
 }
 
@@ -65,6 +67,16 @@ func (GaugeSnapshot) Update(int64) {
 	panic("Update called on a GaugeSnapshot")
 }
 
+// Dec panics.
+func (GaugeSnapshot) Dec(int64) {
+	panic("Dec called on a GaugeSnapshot")
+}
+
+// Inc panics.
+func (GaugeSnapshot) Inc(int64) {
+	panic("Inc called on a GaugeSnapshot")
+}
+
 // Value returns the value at the time the snapshot was taken.
 func (g GaugeSnapshot) Value() int64 { return int64(g) }
 
@@ -76,6 +88,12 @@ func (NilGauge) Snapshot() Gauge { return NilGauge{} }
 
 // Update is a no-op.
 func (NilGauge) Update(v int64) {}
+
+// Dec is a no-op.
+func (NilGauge) Dec(i int64) {}
+
+// Inc is a no-op.
+func (NilGauge) Inc(i int64) {}
 
 // Value is a no-op.
 func (NilGauge) Value() int64 { return 0 }
@@ -94,6 +112,16 @@ func (g *StandardGauge) Snapshot() Gauge {
 // Update updates the gauge's value.
 func (g *StandardGauge) Update(v int64) {
 	atomic.StoreInt64(&g.value, v)
+}
+
+// Dec decrements the gauge's current value by the given amount.
+func (g *StandardGauge) Dec(i int64) {
+	atomic.AddInt64(&g.value, -i)
+}
+
+// Inc increments the gauge's current value by the given amount.
+func (g *StandardGauge) Inc(i int64) {
+	atomic.AddInt64(&g.value, i)
 }
 
 // Value returns the gauge's current value.
@@ -117,4 +145,14 @@ func (g FunctionalGauge) Snapshot() Gauge { return GaugeSnapshot(g.Value()) }
 // Update panics.
 func (FunctionalGauge) Update(int64) {
 	panic("Update called on a FunctionalGauge")
+}
+
+// Dec panics.
+func (FunctionalGauge) Dec(int64) {
+	panic("Dec called on a FunctionalGauge")
+}
+
+// Inc panics.
+func (FunctionalGauge) Inc(int64) {
+	panic("Inc called on a FunctionalGauge")
 }

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -146,7 +146,7 @@ func newDialState(static []*discover.Node, bootnodes []*discover.Node, ntab disc
 }
 
 func (s *dialstate) addStatic(n *discover.Node) {
-	// This overwites the task instead of updating an existing
+	// This overwrites the task instead of updating an existing
 	// entry, giving users the opportunity to force a resolve operation.
 	s.static[n.ID] = &dialTask{flags: staticDialedConn, dest: n}
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -39,9 +39,13 @@ import (
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
 	Code       uint64
-	Size       uint32 // size of the paylod
+	Size       uint32 // Size of the raw payload
 	Payload    io.Reader
 	ReceivedAt time.Time
+
+	meterCap  Cap    // Protocol name and version for egress metering
+	meterCode uint64 // Message within protocol for egress metering
+	meterSize uint32 // Compressed message size for ingress metering
 }
 
 // Decode parses the RLP content of a message into
@@ -100,12 +104,11 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
-//    SendItems(w, code, e1, e2, e3)
+//	SendItems(w, code, e1, e2, e3)
 //
 // the message payload will be an RLP list containing the items:
 //
-//    [e1, e2, e3]
-//
+//	[e1, e2, e3]
 func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
 	return Send(w, msgcode, elems)
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -24,11 +24,20 @@ import (
 	"github.com/tomochain/tomochain/metrics"
 )
 
+const (
+	// ingressMeterName is the prefix of the per-packet inbound metrics.
+	ingressMeterName = "p2p/ingress"
+
+	// egressMeterName is the prefix of the per-packet outbound metrics.
+	egressMeterName = "p2p/egress"
+)
+
 var (
-	ingressConnectMeter = metrics.NewRegisteredMeter("p2p/InboundConnects", nil)
-	ingressTrafficMeter = metrics.NewRegisteredMeter("p2p/InboundTraffic", nil)
-	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/OutboundConnects", nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter("p2p/OutboundTraffic", nil)
+	ingressConnectMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
+	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
+	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/dials", nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
+	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)
 )
 
 // meteredConn is a wrapper around a network TCP connection that meters both the
@@ -51,6 +60,7 @@ func newMeteredConn(conn net.Conn, ingress bool) net.Conn {
 	} else {
 		egressConnectMeter.Mark(1)
 	}
+	activePeerGauge.Inc(1)
 	return &meteredConn{conn.(*net.TCPConn)}
 }
 
@@ -68,4 +78,14 @@ func (c *meteredConn) Write(b []byte) (n int, err error) {
 	n, err = c.TCPConn.Write(b)
 	egressTrafficMeter.Mark(int64(n))
 	return
+}
+
+// Close delegates a close operation to the underlying connection, unregisters
+// the peer from the traffic registries and emits close event.
+func (c *meteredConn) Close() error {
+	err := c.TCPConn.Close()
+	if err == nil {
+		activePeerGauge.Dec(1)
+	}
+	return err
 }

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tomochain/tomochain/crypto/ecies"
 	"github.com/tomochain/tomochain/crypto/secp256k1"
 	"github.com/tomochain/tomochain/crypto/sha3"
+	"github.com/tomochain/tomochain/metrics"
 	"github.com/tomochain/tomochain/p2p/discover"
 	"github.com/tomochain/tomochain/rlp"
 )
@@ -611,6 +612,10 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 
 		msg.Payload = bytes.NewReader(payload)
 		msg.Size = uint32(len(payload))
+	}
+	msg.meterSize = msg.Size
+	if metrics.Enabled && msg.meterCap.Name != "" { // don't meter non-subprotocol messages
+		metrics.GetOrRegisterMeter(fmt.Sprintf("%s/%s/%d/%#02x", egressMeterName, msg.meterCap.Name, msg.meterCap.Version, msg.meterCode), nil).Mark(int64(msg.meterSize))
 	}
 	// write header
 	headbuf := make([]byte, 32)


### PR DESCRIPTION
This pull request includes several changes to the `metrics` and `p2p` packages to enhance functionality and improve code quality. The most important changes include the addition of increment and decrement methods to the `Gauge` interface, updates to the `p2p` package for better metrics tracking, and minor code corrections.

### Enhancements to `metrics` package:

* Added `Inc` and `Dec` methods to the `Gauge` interface and implemented these methods for `GaugeSnapshot`, `NilGauge`, and `StandardGauge` types. (`metrics/gauge.go`) [[1]](diffhunk://#diff-6e5afc030efe825b3fd8af7562d98c8fa5519826b3f1087f7b9edd6e15e7d91fR9-R10) [[2]](diffhunk://#diff-6e5afc030efe825b3fd8af7562d98c8fa5519826b3f1087f7b9edd6e15e7d91fR70-R79) [[3]](diffhunk://#diff-6e5afc030efe825b3fd8af7562d98c8fa5519826b3f1087f7b9edd6e15e7d91fR92-R97) [[4]](diffhunk://#diff-6e5afc030efe825b3fd8af7562d98c8fa5519826b3f1087f7b9edd6e15e7d91fR117-R126) [[5]](diffhunk://#diff-6e5afc030efe825b3fd8af7562d98c8fa5519826b3f1087f7b9edd6e15e7d91fR149-R158)

### Updates to `p2p` package:

* Introduced new constants for ingress and egress meter names and updated existing metrics to use these constants. (`p2p/metrics.go`)
* Added `activePeerGauge` to track the number of active peers and updated connection handling to increment and decrement this gauge appropriately. (`p2p/metrics.go`) [[1]](diffhunk://#diff-b28b34411cbe90dfb54d172f4001643cb91a6686b3476dac06bbd275e1ab29a5R63) [[2]](diffhunk://#diff-b28b34411cbe90dfb54d172f4001643cb91a6686b3476dac06bbd275e1ab29a5R82-R91)
* Enhanced message handling to include metering for ingress and egress traffic. (`p2p/message.go`, `p2p/peer.go`, `p2p/rlpx.go`) [[1]](diffhunk://#diff-160e262a9d225295ceb99f7cd10dedbf58cfd340f1892c84dc8597da8e9131ecL42-R48) [[2]](diffhunk://#diff-160e262a9d225295ceb99f7cd10dedbf58cfd340f1892c84dc8597da8e9131ecL108) [[3]](diffhunk://#diff-56fdd197da1151147beaf6e468b618992fb58797786d85dfe2c2c6a42515d94eR30) [[4]](diffhunk://#diff-56fdd197da1151147beaf6e468b618992fb58797786d85dfe2c2c6a42515d94eR293-R297) [[5]](diffhunk://#diff-56fdd197da1151147beaf6e468b618992fb58797786d85dfe2c2c6a42515d94eR397-R399) [[6]](diffhunk://#diff-68b13ec5f86dbde87df0d9c4a7f8d9ca563dee9d9440a05f86b360f498982f49R43) [[7]](diffhunk://#diff-68b13ec5f86dbde87df0d9c4a7f8d9ca563dee9d9440a05f86b360f498982f49R616-R619)

```
	// ingressMeterName is the prefix of the per-packet inbound metrics.
	ingressMeterName = "p2p/ingress"

	// egressMeterName is the prefix of the per-packet outbound metrics.
	egressMeterName = "p2p/egress"
	ingressConnectMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/dials", nil)
	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)
```
### New `p2p` metrics: 
```
# TYPE p2p_dials gauge
p2p_dials 2

# TYPE p2p_egress gauge
p2p_egress 678287

# TYPE p2p_egress_eth_63_0x00 gauge
p2p_egress_eth_63_0x00 610

# TYPE p2p_egress_eth_63_0x02 gauge
p2p_egress_eth_63_0x02 165096

# TYPE p2p_egress_eth_63_0x03 gauge
p2p_egress_eth_63_0x03 362

# TYPE p2p_egress_eth_63_0x04 gauge
p2p_egress_eth_63_0x04 9446

# TYPE p2p_egress_eth_63_0x05 gauge
p2p_egress_eth_63_0x05 1434

# TYPE p2p_egress_eth_63_0x06 gauge
p2p_egress_eth_63_0x06 7970

# TYPE p2p_egress_eth_63_0x07 gauge
p2p_egress_eth_63_0x07 376172

# TYPE p2p_ingress gauge
p2p_ingress 709796

# TYPE p2p_ingress_eth_63_0x00 gauge
p2p_ingress_eth_63_0x00 0

# TYPE p2p_ingress_eth_63_0x00_packets gauge
p2p_ingress_eth_63_0x00_packets 8

# TYPE p2p_ingress_eth_63_0x02 gauge
p2p_ingress_eth_63_0x02 0

# TYPE p2p_ingress_eth_63_0x02_packets gauge
p2p_ingress_eth_63_0x02_packets 1300

# TYPE p2p_ingress_eth_63_0x03 gauge
p2p_ingress_eth_63_0x03 0

# TYPE p2p_ingress_eth_63_0x03_packets gauge
p2p_ingress_eth_63_0x03_packets 20

# TYPE p2p_ingress_eth_63_0x04 gauge
p2p_ingress_eth_63_0x04 0

# TYPE p2p_ingress_eth_63_0x04_packets gauge
p2p_ingress_eth_63_0x04_packets 25

# TYPE p2p_ingress_eth_63_0x05 gauge
p2p_ingress_eth_63_0x05 0

# TYPE p2p_ingress_eth_63_0x05_packets gauge
p2p_ingress_eth_63_0x05_packets 16

# TYPE p2p_ingress_eth_63_0x06 gauge
p2p_ingress_eth_63_0x06 0

# TYPE p2p_ingress_eth_63_0x06_packets gauge
p2p_ingress_eth_63_0x06_packets 19

# TYPE p2p_ingress_eth_63_0x07 gauge
p2p_ingress_eth_63_0x07 0

# TYPE p2p_ingress_eth_63_0x07_packets gauge
p2p_ingress_eth_63_0x07_packets 482

# TYPE p2p_peers gauge
p2p_peers 6

# TYPE p2p_serves gauge
p2p_serves 6
```


### Code corrections:

* Fixed a typo in a comment within the `p2p/dial.go` file. (`p2p/dial.go`)

### Reference: 

- https://github.com/ethereum/go-ethereum/pull/17695
- https://github.com/ethereum/go-ethereum/pull/19692
- https://github.com/ethereum/go-ethereum/pull/20133
- https://github.com/ethereum/go-ethereum/pull/20679