### PR TITLE
internal/api: support block number or hash on state-related methods

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -88,6 +88,23 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
 }
 
+func (b *EthApiBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.HeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return header, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *EthApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	return b.eth.blockchain.GetHeaderByHash(hash), nil
 }
@@ -145,6 +162,27 @@ func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err
+}
+
+func (b *EthApiBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.StateAndHeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header, err := b.HeaderByHash(ctx, hash)
+		if err != nil {
+			return nil, nil, err
+		}
+		if header == nil {
+			return nil, nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, nil, errors.New("hash is not currently canonical")
+		}
+		stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+		return stateDb, header, err
+	}
+	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
 func (b *EthApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -19,9 +19,10 @@ package ethapi
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"github.com/tomochain/tomochain/tomoxlending"
-	"math/big"
 
 	"github.com/tomochain/tomochain/tomox"
 
@@ -56,9 +57,12 @@ type Backend interface {
 	// BlockChain API
 	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error)
+	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int


### PR DESCRIPTION
This pull request introduces several significant changes to the Ethereum API backend, including the addition of new methods to handle block numbers or hashes interchangeably. The changes focus on enhancing the flexibility and functionality of the API by allowing functions to accept either a block number or a hash as an argument.

# Updated methods support block number or block hash:

- `eth_balance`
- `eth_code`
- `eth_getStorageAt`
- `eth_call`
- `eth_estimateGas`
- `eth_getTransactionCount`

### New Methods for Handling Block Numbers or Hashes:
* [`eth/api_backend.go`](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R91-R107): Added `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash` methods to handle requests using either block numbers or hashes. [[1]](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R91-R107) [[2]](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R167-R187)

### Updates to Existing Methods to Use New Functionality:
* [`internal/ethapi/api.go`](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L521-R523): Updated methods such as `GetBalance`, `GetCode`, `GetStorageAt`, `Call`, `EstimateGas`, and `GetTransactionCount` to use the new `StateAndHeaderByNumberOrHash` method. [[1]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L521-R523) [[2]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L611-R613) [[3]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L623-R625) [[4]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1057-R1061) [[5]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1099-R1100) [[6]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1136-R1147) [[7]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1158-R1159) [[8]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1170-R1171) [[9]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1619-R1630)

### Backend Interface and Implementation Updates:
* [`internal/ethapi/backend.go`](diffhunk://#diff-bca1b856687750650ac87aaf84483b4b3785d9a60fb4440a0fe6b42294889a75R60-R65): Updated the `Backend` interface to include the new methods `HeaderByHash`, `HeaderByNumberOrHash`, and `StateAndHeaderByNumberOrHash`.
* [`les/api_backend.go`](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR76-R95): Implemented the new methods `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash` in the `LesApiBackend` struct. [[1]](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR76-R95) [[2]](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR140-R156)

### Test Updates:
* [`internal/ethapi/api_test.go`](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R95-R115): Added tests for the new methods and updated existing tests to use the new `BlockNumberOrHash` type. [[1]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R95-R115) [[2]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R157-R177) [[3]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815L377-R420)

### Minor Changes:
* [`internal/ethapi/api.go`](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L24-R30): Reorganized import statements for better readability. [[1]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L24-R30) [[2]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R9-R15) [[3]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815L29-L34)
* [`internal/ethapi/backend.go`](diffhunk://#diff-bca1b856687750650ac87aaf84483b4b3785d9a60fb4440a0fe6b42294889a75R22-L24): Reorganized import statements for better readability.