### PR TITLE
internal/api: support block number or hash on state-related methods

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -88,6 +88,23 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
 }
 
+func (b *EthApiBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.HeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return header, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *EthApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	return b.eth.blockchain.GetHeaderByHash(hash), nil
 }
@@ -145,6 +162,27 @@ func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err
+}
+
+func (b *EthApiBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.StateAndHeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header, err := b.HeaderByHash(ctx, hash)
+		if err != nil {
+			return nil, nil, err
+		}
+		if header == nil {
+			return nil, nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, nil, errors.New("hash is not currently canonical")
+		}
+		stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+		return stateDb, header, err
+	}
+	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
 func (b *EthApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -19,9 +19,10 @@ package ethapi
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"github.com/tomochain/tomochain/tomoxlending"
-	"math/big"
 
 	"github.com/tomochain/tomochain/tomox"
 
@@ -56,9 +57,12 @@ type Backend interface {
 	// BlockChain API
 	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error)
+	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int


### PR DESCRIPTION
This pull request introduces significant changes to the Viction API backend to support querying by both block number and block hash. The changes include adding new methods to handle `BlockNumberOrHash` types and updating existing methods to use these new methods.

## Methods updated: 

- `eth_getBalance`
- `eth_getStorageAt`
- `eth_getCode`
- `eth_getTransactionCount`
- `eth_call`
- `eth_estimateGas`

### Support for `BlockNumberOrHash`:

* [`eth/api_backend.go`](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R91-R107): Added `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash` methods to handle queries by either block number or block hash. [[1]](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R91-R107) [[2]](diffhunk://#diff-9886da3412b43831145f62cec6e895eb3613a175b945e5b026543b7463454603R167-R187)
* [`les/api_backend.go`](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR76-R95): Added `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash` methods to the LES API backend. [[1]](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR76-R95) [[2]](diffhunk://#diff-34c2f329c13eb1c8e497f5640cf551aa7083d3bd643307e7e9bc3fbd0310116aR140-R156)

### Updates to PublicBlockChainAPI:

* [`internal/ethapi/api.go`](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L521-R523): Updated methods such as `GetBalance`, `GetCode`, `GetStorageAt`, `Call`, `EstimateGas`, and `GetTransactionCount` to use `StateAndHeaderByNumberOrHash`. [[1]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L521-R523) [[2]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L611-R613) [[3]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L623-R625) [[4]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1057-R1061) [[5]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1099-R1100) [[6]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1136-R1147) [[7]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1158-R1159) [[8]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1170-R1171) [[9]](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1619-R1630)

### Backend Interface Update:

* [`internal/ethapi/backend.go`](diffhunk://#diff-bca1b856687750650ac87aaf84483b4b3785d9a60fb4440a0fe6b42294889a75R60-R65): Updated the `Backend` interface to include the new `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash` methods.

### Test Updates:

* [`internal/ethapi/api_test.go`](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R95-R115): Added new methods to the test backend to support `HeaderByNumberOrHash` and `StateAndHeaderByNumberOrHash`. Updated tests to use `BlockNumberOrHash`. [[1]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R95-R115) [[2]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R157-R177) [[3]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815L377-R420)

### Miscellaneous:

* [`internal/ethapi/api.go`](diffhunk://#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L24-R30): Fixed import ordering.
* [`internal/ethapi/api_test.go`](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R9-R15): Fixed import ordering. [[1]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815R9-R15) [[2]](diffhunk://#diff-6d0f72e0732b99a2f915fe5ef1fd19f8f85a84627eceba96582ac4509c198815L29-L34)
* [`internal/ethapi/backend.go`](diffhunk://#diff-bca1b856687750650ac87aaf84483b4b3785d9a60fb4440a0fe6b42294889a75R22-L24): Fixed import ordering.

### Referrence:
- https://github.com/ethereum/go-ethereum/pull/19491