### PR TITLE
Deprecate TomoX service

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -246,29 +246,18 @@ func ApplyTransaction(config *params.ChainConfig, tokensFee map[common.Address]*
 	if tx.To() != nil && tx.To().String() == common.BlockSigners && config.IsTIPSigning(header.Number) {
 		return ApplySignTransaction(config, statedb, header, tx, usedGas)
 	}
-	// If TomoX is disabled via hardfork, reject all TomoX-related transactions
-	if config.IsExperimental(header.Number) {
-		if (tx.To() != nil && tx.To().String() == common.TradingStateAddr) ||
-			(tx.To() != nil && tx.To().String() == common.TomoXLendingAddress) ||
-			tx.IsTradingTransaction() ||
-			tx.IsLendingFinalizedTradeTransaction() {
-			return nil, 0, fmt.Errorf("TomoX feature is disabled"), false
-		}
-	} else if config.IsTIPTomoX(header.Number) {
+	if tx.To() != nil && tx.To().String() == common.TradingStateAddr && config.IsTIPTomoX(header.Number) {
+		return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
+	}
+	if tx.To() != nil && tx.To().String() == common.TomoXLendingAddress && config.IsTIPTomoX(header.Number) {
+		return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
+	}
+	if tx.IsTradingTransaction() && config.IsTIPTomoX(header.Number) {
+		return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
+	}
 
-		if tx.To() != nil && tx.To().String() == common.TradingStateAddr {
-			return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
-		}
-		if tx.To() != nil && tx.To().String() == common.TomoXLendingAddress {
-			return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
-		}
-		if tx.IsTradingTransaction() {
-			return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
-		}
-
-		if tx.IsLendingFinalizedTradeTransaction() {
-			return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
-		}
+	if tx.IsLendingFinalizedTradeTransaction() && config.IsTIPTomoX(header.Number) {
+		return ApplyEmptyTransaction(config, statedb, header, tx, usedGas)
 	}
 
 	var balanceFee *big.Int

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -112,12 +112,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 				return nil, nil, 0, err
 			}
 		}
-
-		if !p.config.IsExperimental(block.Number()) {
+		blockNumber := block.Number()
+		if !p.config.IsExperimental(blockNumber) && p.config.IsTIPTomoX(blockNumber) {
 			// validate balance slot, token decimal for TomoX
 			if tx.IsTomoXApplyTransaction() {
 				copyState := statedb.Copy()
-				if err := ValidateTomoXApplyTransaction(p.bc, block.Number(), copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				if err := ValidateTomoXApplyTransaction(p.bc, blockNumber, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
 					return nil, nil, 0, err
 				}
 			}
@@ -202,11 +202,12 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 			}
 		}
 
-		if !p.config.IsExperimental(block.Number()) {
+		blockNumber := block.Number()
+		if !p.config.IsExperimental(blockNumber) && p.config.IsTIPTomoX(blockNumber) {
 			// validate balance slot, token decimal for TomoX
 			if tx.IsTomoXApplyTransaction() {
 				copyState := statedb.Copy()
-				if err := ValidateTomoXApplyTransaction(p.bc, block.Number(), copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				if err := ValidateTomoXApplyTransaction(p.bc, blockNumber, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
 					return nil, nil, 0, err
 				}
 			}

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -17,6 +17,10 @@ package core
 
 import (
 	"fmt"
+	"math/big"
+	"math/rand"
+	"strings"
+
 	ethereum "github.com/tomochain/tomochain"
 	"github.com/tomochain/tomochain/accounts/abi"
 	"github.com/tomochain/tomochain/common"
@@ -25,9 +29,6 @@ import (
 	"github.com/tomochain/tomochain/core/state"
 	"github.com/tomochain/tomochain/core/vm"
 	"github.com/tomochain/tomochain/log"
-	"math/big"
-	"math/rand"
-	"strings"
 )
 
 const (
@@ -85,7 +86,7 @@ func RunContract(chain consensus.ChainContext, statedb *state.StateDB, contractA
 	return unpackResult, nil
 }
 
-//FIXME: please use copyState for this function
+// FIXME: please use copyState for this function
 // CallContractWithState executes a contract call at the given state.
 func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, statedb *state.StateDB) ([]byte, error) {
 	// Ensure message is initialized properly.
@@ -123,6 +124,11 @@ func ValidateTomoXApplyTransaction(chain consensus.ChainContext, blockNumber *bi
 	if blockNumber == nil || blockNumber.Sign() <= 0 {
 		blockNumber = chain.CurrentHeader().Number
 	}
+	// Skip validation if TomoX is disabled via Experimental hardfork
+	if chain.Config().IsExperimental(blockNumber) {
+		return nil
+	}
+
 	if !chain.Config().IsTIPTomoX(blockNumber) {
 		return nil
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -688,7 +688,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ValidateTomoZApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:]))
 	}
 
-	if !pool.chain.Config().IsExperimental(pool.chain.CurrentHeader().Number) {
+	blockNumber := pool.chain.CurrentHeader().Number
+	if !pool.chain.Config().IsExperimental(blockNumber) && pool.chain.Config().IsTIPTomoX(blockNumber) {
 		// validate balance slot, token decimal for TomoX
 		if tx.IsTomoXApplyTransaction() {
 			copyState := pool.currentState.Copy()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -688,10 +688,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ValidateTomoZApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:]))
 	}
 
-	// validate balance slot, token decimal for TomoX
-	if tx.IsTomoXApplyTransaction() {
-		copyState := pool.currentState.Copy()
-		return ValidateTomoXApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:]))
+	if !pool.chain.Config().IsExperimental(pool.chain.CurrentHeader().Number) {
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+			copyState := pool.currentState.Copy()
+			return ValidateTomoXApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:]))
+		}
 	}
 	return nil
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -54,7 +54,8 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			precompiles = PrecompiledContractsIstanbul
 		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
-			if !evm.ChainConfig().IsExperimental(evm.BlockNumber) {
+			blockNumber := evm.BlockNumber
+			if !evm.ChainConfig().IsExperimental(blockNumber) && evm.ChainConfig().IsTIPTomoX(blockNumber) {
 				switch p.(type) {
 				case *tomoxEpochPrice:
 					p.(*tomoxEpochPrice).SetTradingState(evm.tradingStateDB)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,12 +17,13 @@
 package vm
 
 import (
-	"github.com/tomochain/tomochain/tomox/tradingstate"
 	"errors"
-	"github.com/tomochain/tomochain/params"
 	"math/big"
 	"sync/atomic"
 	"time"
+
+	"github.com/tomochain/tomochain/params"
+	"github.com/tomochain/tomochain/tomox/tradingstate"
 
 	"github.com/tomochain/tomochain/common"
 	"github.com/tomochain/tomochain/crypto"
@@ -53,11 +54,13 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			precompiles = PrecompiledContractsIstanbul
 		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
-			switch p.(type) {
-			case *tomoxEpochPrice:
-				p.(*tomoxEpochPrice).SetTradingState(evm.tradingStateDB)
-			case *tomoxLastPrice:
-				p.(*tomoxLastPrice).SetTradingState(evm.tradingStateDB)
+			if !evm.ChainConfig().IsExperimental(evm.BlockNumber) {
+				switch p.(type) {
+				case *tomoxEpochPrice:
+					p.(*tomoxEpochPrice).SetTradingState(evm.tradingStateDB)
+				case *tomoxLastPrice:
+					p.(*tomoxLastPrice).SetTradingState(evm.tradingStateDB)
+				}
 			}
 			return RunPrecompiledContract(p, input, contract)
 		}
@@ -150,13 +153,13 @@ type EVM struct {
 // only ever be used *once*.
 func NewEVM(ctx Context, statedb StateDB, tradingStateDB *tradingstate.TradingStateDB, chainConfig *params.ChainConfig, vmConfig Config) *EVM {
 	evm := &EVM{
-		Context:      ctx,
-		StateDB:      statedb,
+		Context:        ctx,
+		StateDB:        statedb,
 		tradingStateDB: tradingStateDB,
-		vmConfig:     vmConfig,
-		chainConfig:  chainConfig,
-		chainRules:   chainConfig.Rules(ctx.BlockNumber),
-		interpreters: make([]Interpreter, 0, 1),
+		vmConfig:       vmConfig,
+		chainConfig:    chainConfig,
+		chainRules:     chainConfig.Rules(ctx.BlockNumber),
+		interpreters:   make([]Interpreter, 0, 1),
 	}
 
 	// vmConfig.EVMInterpreter will be used by EVM-C, it won't be checked here
@@ -355,11 +358,14 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 		evm.StateDB.AddBalance(addr, bigZero)
 	}
 
-
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in Homestead this also counts for code storage gas errors.
-	ret, err = run(evm, contract, input, evm.ChainConfig().IsTIPTomoXCancellationFee(evm.BlockNumber))
+	if evm.ChainConfig().IsExperimental(evm.BlockNumber) {
+		ret, err = run(evm, contract, input, true)
+	} else {
+		ret, err = run(evm, contract, input, evm.ChainConfig().IsTIPTomoXCancellationFee(evm.BlockNumber))
+	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
 		if err != ErrExecutionReverted {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -214,6 +214,13 @@ func (b *EthApiBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	vmError := func() error { return nil }
 
 	context := core.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
+
+	// Check if TomoX is disabled via Experimental hardfork
+	if b.ChainConfig().IsExperimental(header.Number) && tomoxState != nil {
+		// If TomoX is disabled, set tomoxState to nil to prevent any TomoX operations
+		tomoxState = nil
+	}
+
 	return vm.NewEVM(context, state, tomoxState, b.eth.chainConfig, vmCfg), vmError, nil
 }
 
@@ -519,9 +526,17 @@ func (b *EthApiBackend) GetOrderNonce(address common.Hash) (uint64, error) {
 }
 
 func (b *EthApiBackend) TomoxService() *tomox.TomoX {
+	// Return nil if TomoX is disabled due to Experimental hardfork
+	if b.ChainConfig().IsExperimental(b.CurrentBlock().Number()) {
+		return nil
+	}
 	return b.eth.TomoX
 }
 
 func (b *EthApiBackend) LendingService() *tomoxlending.Lending {
+	// Return nil if TomoX is disabled due to Experimental hardfork
+	if b.ChainConfig().IsExperimental(b.CurrentBlock().Number()) {
+		return nil
+	}
 	return b.eth.Lending
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -117,7 +117,7 @@ func (s *Ethereum) AddLesServer(ls LesServer) {
 }
 
 // New creates a new Ethereum object (including the
-// initialisation of the common Ethereum object)
+// initialization of the common Ethereum object)
 func New(ctx *node.ServiceContext, config *Config, tomoXServ *tomox.TomoX, lendingServ *tomoxlending.Lending) (*Ethereum, error) {
 	if config.SyncMode == downloader.LightSync {
 		return nil, errors.New("can't run eth.Ethereum in light sync mode, use les.LightEthereum")

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1104,7 +1104,8 @@ func (s *PublicBlockChainAPI) doCall(ctx context.Context, args CallArgs, blockNr
 
 	// Try to get the TomoxService - it might be nil if TomoX is disabled
 	var tomoxState *tradingstate.TradingStateDB
-	if !s.b.ChainConfig().IsExperimental(block.Number()) {
+	blockNumber := block.Number()
+	if !s.b.ChainConfig().IsExperimental(blockNumber) && s.b.ChainConfig().IsTIPTomoX(blockNumber) {
 
 		author, err := s.b.GetEngine().Author(block.Header())
 		if err != nil {

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -74,10 +74,13 @@ type TxPool struct {
 //
 // Send instructs backend to forward new transactions
 // NewHead notifies backend about a new head after processed by the tx pool,
-//  including  mined and rolled back transactions since the last event
+//
+//	including  mined and rolled back transactions since the last event
+//
 // Discard notifies backend about transactions that should be discarded either
-//  because they have been replaced by a re-send or because they have been mined
-//  long ago and no rollback is expected
+//
+//	because they have been replaced by a re-send or because they have been mined
+//	long ago and no rollback is expected
 type TxRelayBackend interface {
 	Send(txs types.Transactions)
 	NewHead(head common.Hash, mined []common.Hash, rollback []common.Hash)
@@ -360,11 +363,16 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 			return err
 		}
 	}
-	// validate balance slot, token decimal for TomoX
-	if tx.IsTomoXApplyTransaction() {
-		copyState := pool.currentState(ctx).Copy()
-		if err := core.ValidateTomoXApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
-			return err
+	// Skip validation if TomoX is disabled via Experimental hardfork
+	header := pool.chain.GetHeaderByHash(pool.head)
+	if !pool.config.IsExperimental(header.Number) {
+		// validate balance slot, token decimal for TomoX
+		if tx.IsTomoXApplyTransaction() {
+
+			copyState := pool.currentState(ctx).Copy()
+			if err := core.ValidateTomoXApplyTransaction(pool.chain, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -381,7 +389,6 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 
 	// Check the transaction doesn't exceed the current
 	// block limit gas.
-	header := pool.chain.GetHeaderByHash(pool.head)
 	if header.GasLimit < tx.Gas() {
 		return core.ErrGasLimit
 	}

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -365,7 +365,8 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	}
 	// Skip validation if TomoX is disabled via Experimental hardfork
 	header := pool.chain.GetHeaderByHash(pool.head)
-	if !pool.config.IsExperimental(header.Number) {
+	blockNumber := header.Number
+	if !pool.config.IsExperimental(blockNumber) && pool.config.IsTIPTomoX(blockNumber) {
 		// validate balance slot, token decimal for TomoX
 		if tx.IsTomoXApplyTransaction() {
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -466,9 +466,9 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	var lendingState *lendingstate.LendingStateDB
 
 	if self.config.Posv != nil {
+		parentBlockNumber := parent.Number()
 		// Skip TomoX/Lending if experimental hardfork is active
-		experimentalActive := self.config.IsExperimental(parent.Number())
-		if !experimentalActive {
+		if !self.config.IsExperimental(parentBlockNumber) && self.config.IsTIPTomoX(parentBlockNumber) {
 			tomoX := self.eth.GetTomoX()
 			if tomoX != nil {
 				tomoxState, err = tomoX.GetTradingState(parent, author)
@@ -779,8 +779,9 @@ func (self *worker) commitNewWork() {
 			}
 		}
 
+		blockNumber := header.Number
 		// Skip TomoX/Lending state root transaction if experimental hardfork is active
-		if !self.config.IsExperimental(header.Number) {
+		if !self.config.IsExperimental(blockNumber) && self.config.IsTIPTomoX(blockNumber) {
 			// force adding trading, lending transaction to this block
 			if tradingTransaction != nil {
 				specialTxs = append(specialTxs, tradingTransaction)
@@ -890,7 +891,8 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 			}
 		}
 
-		if !env.config.IsExperimental(env.header.Number) {
+		blockNumber := env.header.Number
+		if !env.config.IsExperimental(blockNumber) && env.config.IsTIPTomoX(blockNumber) {
 			// validate balance slot, token decimal for TomoX
 			if tx.IsTomoXApplyTransaction() {
 				copyState, _ := bc.State()
@@ -1008,7 +1010,8 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 			}
 		}
 
-		if !env.config.IsExperimental(env.header.Number) {
+		blockNumber := env.header.Number
+		if !env.config.IsExperimental(blockNumber) && env.config.IsTIPTomoX(blockNumber) {
 			// validate balance slot, token decimal for TomoX
 			if tx.IsTomoXApplyTransaction() {
 				copyState, _ := bc.State()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -464,18 +464,28 @@ func (self *worker) makeCurrent(parent *types.Block, header *types.Header) error
 	author, _ := self.chain.Engine().Author(parent.Header())
 	var tomoxState *tradingstate.TradingStateDB
 	var lendingState *lendingstate.LendingStateDB
+
 	if self.config.Posv != nil {
-		tomoX := self.eth.GetTomoX()
-		tomoxState, err = tomoX.GetTradingState(parent, author)
-		if err != nil {
-			log.Error("Failed to get tomox state ", "number", parent.Number(), "err", err)
-			return err
-		}
-		lending := self.eth.GetTomoXLending()
-		lendingState, err = lending.GetLendingState(parent, author)
-		if err != nil {
-			log.Error("Failed to get lending state ", "number", parent.Number(), "err", err)
-			return err
+		// Skip TomoX/Lending if experimental hardfork is active
+		experimentalActive := self.config.IsExperimental(parent.Number())
+		if !experimentalActive {
+			tomoX := self.eth.GetTomoX()
+			if tomoX != nil {
+				tomoxState, err = tomoX.GetTradingState(parent, author)
+				if err != nil {
+					log.Error("Failed to get tomox state ", "number", parent.Number(), "err", err)
+					return err
+				}
+			}
+
+			lending := self.eth.GetTomoXLending()
+			if lending != nil {
+				lendingState, err = lending.GetLendingState(parent, author)
+				if err != nil {
+					log.Error("Failed to get lending state ", "number", parent.Number(), "err", err)
+					return err
+				}
+			}
 		}
 	}
 
@@ -769,27 +779,30 @@ func (self *worker) commitNewWork() {
 			}
 		}
 
-		// force adding trading, lending transaction to this block
-		if tradingTransaction != nil {
-			specialTxs = append(specialTxs, tradingTransaction)
-		}
-		if lendingTransaction != nil {
-			specialTxs = append(specialTxs, lendingTransaction)
-		}
-		if lendingFinalizedTradeTransaction != nil {
-			specialTxs = append(specialTxs, lendingFinalizedTradeTransaction)
-		}
+		// Skip TomoX/Lending state root transaction if experimental hardfork is active
+		if !self.config.IsExperimental(header.Number) {
+			// force adding trading, lending transaction to this block
+			if tradingTransaction != nil {
+				specialTxs = append(specialTxs, tradingTransaction)
+			}
+			if lendingTransaction != nil {
+				specialTxs = append(specialTxs, lendingTransaction)
+			}
+			if lendingFinalizedTradeTransaction != nil {
+				specialTxs = append(specialTxs, lendingFinalizedTradeTransaction)
+			}
 
-		TomoxStateRoot := work.tradingState.IntermediateRoot()
-		LendingStateRoot := work.lendingState.IntermediateRoot()
-		txData := append(TomoxStateRoot.Bytes(), LendingStateRoot.Bytes()...)
-		tx := types.NewTransaction(work.state.GetNonce(self.coinbase), common.HexToAddress(common.TradingStateAddr), big.NewInt(0), txMatchGasLimit, big.NewInt(0), txData)
-		txStateRoot, err := wallet.SignTx(accounts.Account{Address: self.coinbase}, tx, self.config.ChainId)
-		if err != nil {
-			log.Error("Fail to create tx state root", "error", err)
-			return
+			TomoxStateRoot := work.tradingState.IntermediateRoot()
+			LendingStateRoot := work.lendingState.IntermediateRoot()
+			txData := append(TomoxStateRoot.Bytes(), LendingStateRoot.Bytes()...)
+			tx := types.NewTransaction(work.state.GetNonce(self.coinbase), common.HexToAddress(common.TradingStateAddr), big.NewInt(0), txMatchGasLimit, big.NewInt(0), txData)
+			txStateRoot, err := wallet.SignTx(accounts.Account{Address: self.coinbase}, tx, self.config.ChainId)
+			if err != nil {
+				log.Error("Fail to create tx state root", "error", err)
+				return
+			}
+			specialTxs = append(specialTxs, txStateRoot)
 		}
-		specialTxs = append(specialTxs, txStateRoot)
 	}
 	work.commitTransactions(self.mux, feeCapacity, txs, specialTxs, self.chain, self.coinbase)
 	// compute uncles for the new block.
@@ -876,13 +889,16 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 				continue
 			}
 		}
-		// validate balance slot, token decimal for TomoX
-		if tx.IsTomoXApplyTransaction() {
-			copyState, _ := bc.State()
-			if err := core.ValidateTomoXApplyTransaction(bc, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
-				log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
-				txs.Pop()
-				continue
+
+		if !env.config.IsExperimental(env.header.Number) {
+			// validate balance slot, token decimal for TomoX
+			if tx.IsTomoXApplyTransaction() {
+				copyState, _ := bc.State()
+				if err := core.ValidateTomoXApplyTransaction(bc, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+					log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+					txs.Pop()
+					continue
+				}
 			}
 		}
 
@@ -991,13 +1007,16 @@ func (env *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Ad
 				continue
 			}
 		}
-		// validate balance slot, token decimal for TomoX
-		if tx.IsTomoXApplyTransaction() {
-			copyState, _ := bc.State()
-			if err := core.ValidateTomoXApplyTransaction(bc, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
-				log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
-				txs.Pop()
-				continue
+
+		if !env.config.IsExperimental(env.header.Number) {
+			// validate balance slot, token decimal for TomoX
+			if tx.IsTomoXApplyTransaction() {
+				copyState, _ := bc.State()
+				if err := core.ValidateTomoXApplyTransaction(bc, nil, copyState, common.BytesToAddress(tx.Data()[4:])); err != nil {
+					log.Debug("TomoXApply: invalid token", "token", common.BytesToAddress(tx.Data()[4:]).Hex())
+					txs.Pop()
+					continue
+				}
 			}
 		}
 

--- a/params/config.go
+++ b/params/config.go
@@ -361,18 +361,10 @@ func (c *ChainConfig) IsTIPTomoX(num *big.Int) bool {
 }
 
 func (c *ChainConfig) IsTIPTomoXLending(num *big.Int) bool {
-	// If we're at or after the Experimental HF block, disable TomoX Lending
-	if c.ExperimentalBlock != nil && isForked(c.ExperimentalBlock, num) {
-		return false
-	}
 	return isForked(common.TIPTomoXLendingBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoXCancellationFee(num *big.Int) bool {
-	// If we're at or after the Experimental HF block, disable TomoX Cancellation Fee
-	if c.ExperimentalBlock != nil && isForked(c.ExperimentalBlock, num) {
-		return false
-	}
 	return isForked(common.TIPTomoXCancellationFeeBlock, num)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -33,14 +33,15 @@ var (
 var (
 	// VicMainnetChainConfig contains the chain parameters to run a Viction node on the main network.
 	VicMainnetChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(88),
-		HomesteadBlock: big.NewInt(1),
-		EIP150Block:    big.NewInt(2),
-		EIP150Hash:     common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-		EIP155Block:    big.NewInt(3),
-		EIP158Block:    big.NewInt(3),
-		ByzantiumBlock: big.NewInt(4),
-		SaigonBlock:    big.NewInt(86158494),
+		ChainId:           big.NewInt(88),
+		HomesteadBlock:    big.NewInt(1),
+		EIP150Block:       big.NewInt(2),
+		EIP150Hash:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		EIP155Block:       big.NewInt(3),
+		EIP158Block:       big.NewInt(3),
+		ByzantiumBlock:    big.NewInt(4),
+		SaigonBlock:       big.NewInt(86158494),
+		ExperimentalBlock: big.NewInt(94300000),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,

--- a/params/config.go
+++ b/params/config.go
@@ -352,14 +352,26 @@ func (c *ChainConfig) IsTIPTRC21Fee(num *big.Int) bool {
 }
 
 func (c *ChainConfig) IsTIPTomoX(num *big.Int) bool {
+	// If we're at or after the Experimental HF block, disable TomoX
+	if c.ExperimentalBlock != nil && isForked(c.ExperimentalBlock, num) {
+		return false
+	}
 	return isForked(common.TIPTomoXBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoXLending(num *big.Int) bool {
+	// If we're at or after the Experimental HF block, disable TomoX Lending
+	if c.ExperimentalBlock != nil && isForked(c.ExperimentalBlock, num) {
+		return false
+	}
 	return isForked(common.TIPTomoXLendingBlock, num)
 }
 
 func (c *ChainConfig) IsTIPTomoXCancellationFee(num *big.Int) bool {
+	// If we're at or after the Experimental HF block, disable TomoX Cancellation Fee
+	if c.ExperimentalBlock != nil && isForked(c.ExperimentalBlock, num) {
+		return false
+	}
 	return isForked(common.TIPTomoXCancellationFeeBlock, num)
 }
 


### PR DESCRIPTION
This pull request introduces a feature flag mechanism to disable TomoX functionality via an "Experimental" hardfork. The changes ensure that TomoX-related transactions and operations are conditionally processed based on the network configuration. The most important changes are grouped below:

### Check Hardfork in config file: 
* Add check hardfork block in `TIPTomoX`. If it reach `ExperimentalBlock`, TomoX will be disabled.

### Core Processing Updates:
* Added checks in `core/state_processor.go` to skip TomoX-related transaction validation and processing when the "Experimental" hardfork is active. 

### API Adjustments:
* Modified `internal/ethapi/api.go` to return errors or bypass TomoX operations (e.g., order transactions, lending transactions, price queries) when the "Experimental" hardfork is enabled.

### EVM Behavior:
* Adjusted `core/vm/evm.go` to prevent TomoX-related precompiled contract operations when the "Experimental" hardfork is active.

### Validation Logic:
* Updated `core/token_validator.go` to skip TomoX transaction validation if the "Experimental" hardfork is enabled.

### Miscellaneous:
* Fixed a minor typo in `eth/backend.go` ("initialisation" → "initialization").