### PR TITLE
Make mine flag and etherbase optional

### DIFF
--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -90,16 +90,15 @@ type Bootnodes struct {
 }
 
 type tomoConfig struct {
-	Eth         eth.Config
-	Shh         whisper.Config
-	Node        node.Config
-	Ethstats    ethstatsConfig
-	TomoX       tomox.Config
-	Account     account
-	StakeEnable bool
-	Bootnodes   Bootnodes
-	Verbosity   int
-	NAT         string
+	Eth       eth.Config
+	Shh       whisper.Config
+	Node      node.Config
+	Ethstats  ethstatsConfig
+	TomoX     tomox.Config
+	Account   account
+	Bootnodes Bootnodes
+	Verbosity int
+	NAT       string
 }
 
 func loadConfig(file string, cfg *tomoConfig) error {
@@ -129,22 +128,18 @@ func defaultNodeConfig() node.Config {
 func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 	// Load defaults.
 	cfg := tomoConfig{
-		Eth:         eth.DefaultConfig,
-		Shh:         whisper.DefaultConfig,
-		TomoX:       tomox.DefaultConfig,
-		Node:        defaultNodeConfig(),
-		StakeEnable: true,
-		Verbosity:   3,
-		NAT:         "",
+		Eth:       eth.DefaultConfig,
+		Shh:       whisper.DefaultConfig,
+		TomoX:     tomox.DefaultConfig,
+		Node:      defaultNodeConfig(),
+		Verbosity: 3,
+		NAT:       "",
 	}
 	// Load config file.
 	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
 		if err := loadConfig(file, &cfg); err != nil {
 			utils.Fatalf("%v", err)
 		}
-	}
-	if ctx.GlobalIsSet(utils.StakingEnabledFlag.Name) {
-		cfg.StakeEnable = ctx.GlobalBool(utils.StakingEnabledFlag.Name)
 	}
 	if !ctx.GlobalIsSet(debug.VerbosityFlag.Name) {
 		debug.Glogger.Verbosity(log.Lvl(cfg.Verbosity))

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -310,7 +310,7 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			started := false
 			ok, err := ethereum.ValidateMasternode()
 			if err != nil {
-				utils.Fatalf("Can't verify masternode permission: %v", err)
+				log.Warn("Cannot get etherbase", "err", err)
 			}
 			if ok {
 				log.Info("Masternode found. Enabling staking mode...")
@@ -325,14 +325,14 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					utils.Fatalf("Failed to start staking: %v", err)
 				}
 				started = true
-				log.Info("Enabled staking node!!!")
+				log.Info("Enabled mining node!!!")
 			}
 			defer close(core.CheckpointCh)
 			for range core.CheckpointCh {
 				log.Info("Checkpoint!!! It's time to reconcile node's state...")
 				ok, err := ethereum.ValidateMasternode()
 				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
+					log.Warn("Cannot get etherbase", "err", err)
 				}
 				if !ok {
 					if started {
@@ -354,7 +354,7 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 						utils.Fatalf("Failed to start staking: %v", err)
 					}
 					started = true
-					log.Info("Enabled staking node!!!")
+					log.Info("Enabled mining node!!!")
 				}
 			}
 		}()

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -314,12 +314,8 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			}
 			if ok {
 				log.Info("Masternode found. Enabling staking mode...")
-				// Use a reduced number of threads if requested
 				if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-					type threaded interface {
-						SetThreads(threads int)
-					}
-					if th, ok := ethereum.Engine().(threaded); ok {
+					if th, ok := ethereum.Engine().(concurrentEngine); ok {
 						th.SetThreads(threads)
 					}
 				}
@@ -347,12 +343,8 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					}
 				} else if !started {
 					log.Info("Masternode found. Enabling staking mode...")
-					// Use a reduced number of threads if requested
 					if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-						type threaded interface {
-							SetThreads(threads int)
-						}
-						if th, ok := ethereum.Engine().(threaded); ok {
+						if th, ok := ethereum.Engine().(concurrentEngine); ok {
 							th.SetThreads(threads)
 						}
 					}
@@ -367,4 +359,9 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			}
 		}()
 	}
+}
+
+// Interface to check a consensus engine can support many threads.
+type concurrentEngine interface {
+	SetThreads(threads int)
 }

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -126,7 +126,6 @@ var (
 		utils.AnnounceTxsFlag,
 		utils.StoreRewardFlag,
 		utils.RollbackFlag,
-		utils.TomoSlaveModeFlag,
 		utils.ReexecFlag,
 	}
 
@@ -309,16 +308,44 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 	if _, ok := ethereum.Engine().(*posv.Posv); ok {
 		go func() {
 			started := false
-			slaveMode := ctx.GlobalIsSet(utils.TomoSlaveModeFlag.Name)
 			ok, err := ethereum.ValidateMasternode()
 			if err != nil {
 				utils.Fatalf("Can't verify masternode permission: %v", err)
 			}
 			if ok {
-				if slaveMode {
-					log.Info("Masternode slave mode found.")
-					started = false
-				} else {
+				log.Info("Masternode found. Enabling staking mode...")
+				// Use a reduced number of threads if requested
+				if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
+					type threaded interface {
+						SetThreads(threads int)
+					}
+					if th, ok := ethereum.Engine().(threaded); ok {
+						th.SetThreads(threads)
+					}
+				}
+				// Set the gas price to the limits from the CLI and start mining
+				ethereum.TxPool().SetGasPrice(cfg.Eth.GasPrice)
+				if err := ethereum.StartStaking(true); err != nil {
+					utils.Fatalf("Failed to start staking: %v", err)
+				}
+				started = true
+				log.Info("Enabled staking node!!!")
+			}
+			defer close(core.CheckpointCh)
+			for range core.CheckpointCh {
+				log.Info("Checkpoint!!! It's time to reconcile node's state...")
+				ok, err := ethereum.ValidateMasternode()
+				if err != nil {
+					utils.Fatalf("Can't verify masternode permission: %v", err)
+				}
+				if !ok {
+					if started {
+						log.Info("Only masternode can propose and verify blocks. Cancelling staking on this node...")
+						ethereum.StopStaking()
+						started = false
+						log.Info("Cancelled mining mode!!!")
+					}
+				} else if !started {
 					log.Info("Masternode found. Enabling staking mode...")
 					// Use a reduced number of threads if requested
 					if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
@@ -336,45 +363,6 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					}
 					started = true
 					log.Info("Enabled staking node!!!")
-				}
-			}
-			defer close(core.CheckpointCh)
-			for range core.CheckpointCh {
-				log.Info("Checkpoint!!! It's time to reconcile node's state...")
-				ok, err := ethereum.ValidateMasternode()
-				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
-				}
-				if !ok {
-					if started {
-						log.Info("Only masternode can propose and verify blocks. Cancelling staking on this node...")
-						ethereum.StopStaking()
-						started = false
-						log.Info("Cancelled mining mode!!!")
-					}
-				} else if !started {
-					if slaveMode {
-						log.Info("Masternode slave mode found.")
-						started = false
-					} else {
-						log.Info("Masternode found. Enabling staking mode...")
-						// Use a reduced number of threads if requested
-						if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-							type threaded interface {
-								SetThreads(threads int)
-							}
-							if th, ok := ethereum.Engine().(threaded); ok {
-								th.SetThreads(threads)
-							}
-						}
-						// Set the gas price to the limits from the CLI and start mining
-						ethereum.TxPool().SetGasPrice(cfg.Eth.GasPrice)
-						if err := ethereum.StartStaking(true); err != nil {
-							utils.Fatalf("Failed to start staking: %v", err)
-						}
-						started = true
-						log.Info("Enabled staking node!!!")
-					}
 				}
 			}
 		}()

--- a/cmd/tomo/testdata/config.toml
+++ b/cmd/tomo/testdata/config.toml
@@ -1,4 +1,3 @@
-StakeEnable	=   true	    # flag  --miner ( true : enable staker , false : disable )
 Verbosity   =   0           # flag  --verbosity (0=Crit 1=Error 2=Warn 3=Info 4=Debug   5=Trace)
 NAT         =   ""          # flag  --nat
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -575,10 +575,6 @@ var (
 		Name:  "tomox.dbReplicaSetName",
 		Usage: "ReplicaSetName if Master-Slave is setup",
 	}
-	TomoSlaveModeFlag = cli.BoolFlag{
-		Name:  "slave",
-		Usage: "Enable slave mode",
-	}
 	ReexecFlag = cli.IntFlag{
 		Name:  "reexec",
 		Usage: "Reexec blocks",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -24,7 +24,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -314,7 +313,7 @@ var (
 	StakerThreadsFlag = cli.IntFlag{
 		Name:  "minerthreads",
 		Usage: "Number of CPU threads to use for staking",
-		Value: runtime.NumCPU(),
+		Value: 1,
 	}
 	TargetGasLimitFlag = cli.Uint64Flag{
 		Name:  "targetgaslimit",


### PR DESCRIPTION
Mine flag has no effective when starting a Viction node. However, when starting a node, an etherbase is still required. This PR will make etherbase optional, either. So if you are not going running a masternode (validator), you will not be forced to create a new account for the node anymore.