### PR TITLE
Remove payerSwap from transaction sorting by price

### DIFF
--- a/cmd/tomo/config.go
+++ b/cmd/tomo/config.go
@@ -90,16 +90,15 @@ type Bootnodes struct {
 }
 
 type tomoConfig struct {
-	Eth         eth.Config
-	Shh         whisper.Config
-	Node        node.Config
-	Ethstats    ethstatsConfig
-	TomoX       tomox.Config
-	Account     account
-	StakeEnable bool
-	Bootnodes   Bootnodes
-	Verbosity   int
-	NAT         string
+	Eth       eth.Config
+	Shh       whisper.Config
+	Node      node.Config
+	Ethstats  ethstatsConfig
+	TomoX     tomox.Config
+	Account   account
+	Bootnodes Bootnodes
+	Verbosity int
+	NAT       string
 }
 
 func loadConfig(file string, cfg *tomoConfig) error {
@@ -129,22 +128,18 @@ func defaultNodeConfig() node.Config {
 func makeConfigNode(ctx *cli.Context) (*node.Node, tomoConfig) {
 	// Load defaults.
 	cfg := tomoConfig{
-		Eth:         eth.DefaultConfig,
-		Shh:         whisper.DefaultConfig,
-		TomoX:       tomox.DefaultConfig,
-		Node:        defaultNodeConfig(),
-		StakeEnable: true,
-		Verbosity:   3,
-		NAT:         "",
+		Eth:       eth.DefaultConfig,
+		Shh:       whisper.DefaultConfig,
+		TomoX:     tomox.DefaultConfig,
+		Node:      defaultNodeConfig(),
+		Verbosity: 3,
+		NAT:       "",
 	}
 	// Load config file.
 	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
 		if err := loadConfig(file, &cfg); err != nil {
 			utils.Fatalf("%v", err)
 		}
-	}
-	if ctx.GlobalIsSet(utils.StakingEnabledFlag.Name) {
-		cfg.StakeEnable = ctx.GlobalBool(utils.StakingEnabledFlag.Name)
 	}
 	if !ctx.GlobalIsSet(debug.VerbosityFlag.Name) {
 		debug.Glogger.Verbosity(log.Lvl(cfg.Verbosity))

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -310,7 +310,7 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			started := false
 			ok, err := ethereum.ValidateMasternode()
 			if err != nil {
-				utils.Fatalf("Can't verify masternode permission: %v", err)
+				log.Warn("Cannot get etherbase", "err", err)
 			}
 			if ok {
 				log.Info("Masternode found. Enabling staking mode...")
@@ -325,14 +325,14 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					utils.Fatalf("Failed to start staking: %v", err)
 				}
 				started = true
-				log.Info("Enabled staking node!!!")
+				log.Info("Enabled mining node!!!")
 			}
 			defer close(core.CheckpointCh)
 			for range core.CheckpointCh {
 				log.Info("Checkpoint!!! It's time to reconcile node's state...")
 				ok, err := ethereum.ValidateMasternode()
 				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
+					log.Warn("Cannot get etherbase", "err", err)
 				}
 				if !ok {
 					if started {
@@ -354,7 +354,7 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 						utils.Fatalf("Failed to start staking: %v", err)
 					}
 					started = true
-					log.Info("Enabled staking node!!!")
+					log.Info("Enabled mining node!!!")
 				}
 			}
 		}()

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -314,12 +314,8 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			}
 			if ok {
 				log.Info("Masternode found. Enabling staking mode...")
-				// Use a reduced number of threads if requested
 				if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-					type threaded interface {
-						SetThreads(threads int)
-					}
-					if th, ok := ethereum.Engine().(threaded); ok {
+					if th, ok := ethereum.Engine().(concurrentEngine); ok {
 						th.SetThreads(threads)
 					}
 				}
@@ -347,12 +343,8 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					}
 				} else if !started {
 					log.Info("Masternode found. Enabling staking mode...")
-					// Use a reduced number of threads if requested
 					if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-						type threaded interface {
-							SetThreads(threads int)
-						}
-						if th, ok := ethereum.Engine().(threaded); ok {
+						if th, ok := ethereum.Engine().(concurrentEngine); ok {
 							th.SetThreads(threads)
 						}
 					}
@@ -367,4 +359,9 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 			}
 		}()
 	}
+}
+
+// Interface to check a consensus engine can support many threads.
+type concurrentEngine interface {
+	SetThreads(threads int)
 }

--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -126,7 +126,6 @@ var (
 		utils.AnnounceTxsFlag,
 		utils.StoreRewardFlag,
 		utils.RollbackFlag,
-		utils.TomoSlaveModeFlag,
 		utils.ReexecFlag,
 	}
 
@@ -309,16 +308,44 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 	if _, ok := ethereum.Engine().(*posv.Posv); ok {
 		go func() {
 			started := false
-			slaveMode := ctx.GlobalIsSet(utils.TomoSlaveModeFlag.Name)
 			ok, err := ethereum.ValidateMasternode()
 			if err != nil {
 				utils.Fatalf("Can't verify masternode permission: %v", err)
 			}
 			if ok {
-				if slaveMode {
-					log.Info("Masternode slave mode found.")
-					started = false
-				} else {
+				log.Info("Masternode found. Enabling staking mode...")
+				// Use a reduced number of threads if requested
+				if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
+					type threaded interface {
+						SetThreads(threads int)
+					}
+					if th, ok := ethereum.Engine().(threaded); ok {
+						th.SetThreads(threads)
+					}
+				}
+				// Set the gas price to the limits from the CLI and start mining
+				ethereum.TxPool().SetGasPrice(cfg.Eth.GasPrice)
+				if err := ethereum.StartStaking(true); err != nil {
+					utils.Fatalf("Failed to start staking: %v", err)
+				}
+				started = true
+				log.Info("Enabled staking node!!!")
+			}
+			defer close(core.CheckpointCh)
+			for range core.CheckpointCh {
+				log.Info("Checkpoint!!! It's time to reconcile node's state...")
+				ok, err := ethereum.ValidateMasternode()
+				if err != nil {
+					utils.Fatalf("Can't verify masternode permission: %v", err)
+				}
+				if !ok {
+					if started {
+						log.Info("Only masternode can propose and verify blocks. Cancelling staking on this node...")
+						ethereum.StopStaking()
+						started = false
+						log.Info("Cancelled mining mode!!!")
+					}
+				} else if !started {
 					log.Info("Masternode found. Enabling staking mode...")
 					// Use a reduced number of threads if requested
 					if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
@@ -336,45 +363,6 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg tomoConfig) {
 					}
 					started = true
 					log.Info("Enabled staking node!!!")
-				}
-			}
-			defer close(core.CheckpointCh)
-			for range core.CheckpointCh {
-				log.Info("Checkpoint!!! It's time to reconcile node's state...")
-				ok, err := ethereum.ValidateMasternode()
-				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
-				}
-				if !ok {
-					if started {
-						log.Info("Only masternode can propose and verify blocks. Cancelling staking on this node...")
-						ethereum.StopStaking()
-						started = false
-						log.Info("Cancelled mining mode!!!")
-					}
-				} else if !started {
-					if slaveMode {
-						log.Info("Masternode slave mode found.")
-						started = false
-					} else {
-						log.Info("Masternode found. Enabling staking mode...")
-						// Use a reduced number of threads if requested
-						if threads := ctx.GlobalInt(utils.StakerThreadsFlag.Name); threads > 0 {
-							type threaded interface {
-								SetThreads(threads int)
-							}
-							if th, ok := ethereum.Engine().(threaded); ok {
-								th.SetThreads(threads)
-							}
-						}
-						// Set the gas price to the limits from the CLI and start mining
-						ethereum.TxPool().SetGasPrice(cfg.Eth.GasPrice)
-						if err := ethereum.StartStaking(true); err != nil {
-							utils.Fatalf("Failed to start staking: %v", err)
-						}
-						started = true
-						log.Info("Enabled staking node!!!")
-					}
 				}
 			}
 		}()

--- a/cmd/tomo/testdata/config.toml
+++ b/cmd/tomo/testdata/config.toml
@@ -1,4 +1,3 @@
-StakeEnable	=   true	    # flag  --miner ( true : enable staker , false : disable )
 Verbosity   =   0           # flag  --verbosity (0=Crit 1=Error 2=Warn 3=Info 4=Debug   5=Trace)
 NAT         =   ""          # flag  --nat
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -575,10 +575,6 @@ var (
 		Name:  "tomox.dbReplicaSetName",
 		Usage: "ReplicaSetName if Master-Slave is setup",
 	}
-	TomoSlaveModeFlag = cli.BoolFlag{
-		Name:  "slave",
-		Usage: "Enable slave mode",
-	}
 	ReexecFlag = cli.IntFlag{
 		Name:  "reexec",
 		Usage: "Reexec blocks",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -24,7 +24,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -314,7 +313,7 @@ var (
 	StakerThreadsFlag = cli.IntFlag{
 		Name:  "minerthreads",
 		Usage: "Number of CPU threads to use for staking",
-		Value: runtime.NumCPU(),
+		Value: 1,
 	}
 	TargetGasLimitFlag = cli.Uint64Flag{
 		Name:  "targetgaslimit",

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -18,9 +18,11 @@ package types
 
 import (
 	"bytes"
+	"container/heap"
 	"crypto/ecdsa"
 	"encoding/json"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/tomochain/tomochain/common"
@@ -144,7 +146,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		}
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, nil, map[common.Address]*big.Int{})
+	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
@@ -230,6 +232,308 @@ func TestTransactionJSON(t *testing.T) {
 		}
 		if tx.ChainId().Cmp(parsedTx.ChainId()) != 0 {
 			t.Errorf("invalid chain id, want %d, got %d", tx.ChainId(), parsedTx.ChainId())
+		}
+	}
+}
+
+// TestTxByPriceSimpleSort tests that transactions are sorted purely by gas price
+// without any special handling for TRC21 or other transaction types.
+func TestTxByPriceSimpleSort(t *testing.T) {
+	// Generate test transactions with different gas prices
+	key, _ := crypto.GenerateKey()
+	signer := HomesteadSigner{}
+
+	// Create transactions with specific gas prices in random order
+	gasPrices := []*big.Int{
+		big.NewInt(500), // highest
+		big.NewInt(100), // lowest
+		big.NewInt(300), // middle
+		big.NewInt(200), // lower middle
+		big.NewInt(400), // upper middle
+	}
+
+	txs := make(Transactions, len(gasPrices))
+	for i, gasPrice := range gasPrices {
+		tx, _ := SignTx(NewTransaction(uint64(i), common.Address{1}, big.NewInt(100), 100, gasPrice, nil), signer, key)
+		txs[i] = tx
+	}
+
+	// Create TxByPrice sorter
+	sorter := TxByPrice(txs)
+
+	// Test Less function directly
+	expectedOrder := []int{0, 4, 2, 3, 1} // indices sorted by gas price descending (500, 400, 300, 200, 100)
+
+	// Verify that higher gas price transactions are considered "less" (higher priority)
+	for i := 0; i < len(expectedOrder)-1; i++ {
+		higherPriceIdx := expectedOrder[i]
+		lowerPriceIdx := expectedOrder[i+1]
+
+		if !sorter.Less(higherPriceIdx, lowerPriceIdx) {
+			t.Errorf("Transaction with gas price %v should have higher priority than %v",
+				sorter[higherPriceIdx].GasPrice(), sorter[lowerPriceIdx].GasPrice())
+		}
+
+		if sorter.Less(lowerPriceIdx, higherPriceIdx) {
+			t.Errorf("Transaction with gas price %v should have lower priority than %v",
+				sorter[lowerPriceIdx].GasPrice(), sorter[higherPriceIdx].GasPrice())
+		}
+	}
+
+	// Test that equal gas prices return false (stable sort)
+	equalGasTx, _ := SignTx(NewTransaction(100, common.Address{2}, big.NewInt(100), 100, big.NewInt(300), nil), signer, key)
+	sorter = append(sorter, equalGasTx)
+
+	// Find the transaction with gas price 300 and compare with the new equal one
+	equalIdx1 := 2               // gas price 300
+	equalIdx2 := len(sorter) - 1 // new tx with gas price 300
+
+	if sorter.Less(equalIdx1, equalIdx2) || sorter.Less(equalIdx2, equalIdx1) {
+		t.Errorf("Transactions with equal gas prices should not be considered less than each other")
+	}
+}
+
+// TestTxByPriceNoTRC21Priority tests that TRC21 transactions (transactions going to
+// addresses in payersSwap) are not given special priority and are sorted purely by gas price.
+func TestTxByPriceNoTRC21Priority(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	signer := HomesteadSigner{}
+
+	// Create addresses that would be in payersSwap (simulating TRC21 contracts)
+	trc21Address1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	trc21Address2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	regularAddress := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	// Create transactions: TRC21 with low gas price, regular with high gas price
+	lowGasPrice := big.NewInt(100)
+	highGasPrice := big.NewInt(500)
+
+	// TRC21 transaction with low gas price
+	trc21LowGasTx, _ := SignTx(NewTransaction(1, trc21Address1, big.NewInt(100), 100, lowGasPrice, nil), signer, key)
+
+	// TRC21 transaction with high gas price
+	trc21HighGasTx, _ := SignTx(NewTransaction(2, trc21Address2, big.NewInt(100), 100, highGasPrice, nil), signer, key)
+
+	// Regular transaction with high gas price
+	regularHighGasTx, _ := SignTx(NewTransaction(3, regularAddress, big.NewInt(100), 100, highGasPrice, nil), signer, key)
+
+	// Regular transaction with low gas price
+	regularLowGasTx, _ := SignTx(NewTransaction(4, regularAddress, big.NewInt(100), 100, lowGasPrice, nil), signer, key)
+
+	txs := Transactions{trc21LowGasTx, trc21HighGasTx, regularHighGasTx, regularLowGasTx}
+
+	// Create TxByPrice sorter (TRC21 addresses no longer affect sorting)
+	sorter := TxByPrice(txs)
+
+	// Test that high gas price transactions (regardless of TRC21 status) beat low gas price ones
+	trc21LowIdx := 0    // TRC21 with low gas price
+	trc21HighIdx := 1   // TRC21 with high gas price
+	regularHighIdx := 2 // Regular with high gas price
+	regularLowIdx := 3  // Regular with low gas price
+
+	// High gas price transactions should beat low gas price ones, regardless of TRC21 status
+	if !sorter.Less(trc21HighIdx, trc21LowIdx) {
+		t.Errorf("TRC21 transaction with high gas price should beat TRC21 transaction with low gas price")
+	}
+
+	if !sorter.Less(regularHighIdx, regularLowIdx) {
+		t.Errorf("Regular transaction with high gas price should beat regular transaction with low gas price")
+	}
+
+	if !sorter.Less(regularHighIdx, trc21LowIdx) {
+		t.Errorf("Regular transaction with high gas price should beat TRC21 transaction with low gas price")
+	}
+
+	if !sorter.Less(trc21HighIdx, regularLowIdx) {
+		t.Errorf("TRC21 transaction with high gas price should beat regular transaction with low gas price")
+	}
+
+	// Transactions with same gas price should be equal priority regardless of TRC21 status
+	if sorter.Less(trc21HighIdx, regularHighIdx) || sorter.Less(regularHighIdx, trc21HighIdx) {
+		t.Errorf("TRC21 and regular transactions with same gas price should have equal priority")
+	}
+
+	if sorter.Less(trc21LowIdx, regularLowIdx) || sorter.Less(regularLowIdx, trc21LowIdx) {
+		t.Errorf("TRC21 and regular transactions with same gas price should have equal priority")
+	}
+}
+
+// TestTxByPriceCompleteSort tests the complete sorting flow using Go's sort package
+// to verify transactions are properly ordered by gas price in descending order.
+func TestTxByPriceCompleteSort(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	signer := HomesteadSigner{}
+
+	// Create transactions with various gas prices including duplicates
+	testCases := []struct {
+		gasPrice int64
+		nonce    uint64
+		to       common.Address
+	}{
+		{1000, 0, common.HexToAddress("0x1000000000000000000000000000000000000000")}, // highest
+		{100, 1, common.HexToAddress("0x1100000000000000000000000000000000000000")},  // lowest
+		{500, 2, common.HexToAddress("0x1500000000000000000000000000000000000000")},  // middle-high
+		{300, 3, common.HexToAddress("0x1300000000000000000000000000000000000000")},  // middle
+		{100, 4, common.HexToAddress("0x1100000000000000000000000000000000000001")},  // lowest (duplicate)
+		{750, 5, common.HexToAddress("0x1750000000000000000000000000000000000000")},  // high
+		{200, 6, common.HexToAddress("0x1200000000000000000000000000000000000000")},  // low
+		{500, 7, common.HexToAddress("0x1500000000000000000000000000000000000001")},  // middle-high (duplicate)
+	}
+
+	// Create transactions
+	var txs Transactions
+	for _, tc := range testCases {
+		tx, _ := SignTx(NewTransaction(tc.nonce, tc.to, big.NewInt(100), 100, big.NewInt(tc.gasPrice), nil), signer, key)
+		txs = append(txs, tx)
+	}
+
+	// Create sorter (TRC21 addresses no longer affect sorting since payersSwap was removed)
+	sorter := (*TxByPrice)(&txs)
+
+	// Sort using Go's sort package
+	sort.Sort(sorter)
+
+	// Expected order: 1000, 750, 500, 500, 300, 200, 100, 100
+	expectedGasPrices := []int64{1000, 750, 500, 500, 300, 200, 100, 100}
+
+	// Verify sorted order
+	if len(*sorter) != len(expectedGasPrices) {
+		t.Fatalf("Expected %d transactions, got %d", len(expectedGasPrices), len(*sorter))
+	}
+
+	for i, expectedPrice := range expectedGasPrices {
+		actualPrice := (*sorter)[i].GasPrice().Int64()
+		if actualPrice != expectedPrice {
+			t.Errorf("Transaction at index %d: expected gas price %d, got %d", i, expectedPrice, actualPrice)
+		}
+	}
+
+	// Verify that transactions are in descending order
+	for i := 0; i < len(*sorter)-1; i++ {
+		currentPrice := (*sorter)[i].GasPrice()
+		nextPrice := (*sorter)[i+1].GasPrice()
+		if currentPrice.Cmp(nextPrice) < 0 {
+			t.Errorf("Transactions not in descending order: position %d (%v) < position %d (%v)",
+				i, currentPrice, i+1, nextPrice)
+		}
+	}
+
+	// Note: TRC21 special handling was removed, so all transactions are sorted purely by gas price
+	// The following test now just verifies that all transactions are properly sorted by gas price
+}
+
+// TestTxByPriceHeapOperations tests the heap operations (Push/Pop) to ensure
+// they maintain proper ordering after sorting modifications.
+func TestTxByPriceHeapOperations(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	signer := HomesteadSigner{}
+
+	// Create initial transactions
+	gasPrices := []int64{300, 100, 500, 200}
+	var txs Transactions
+	for i, gasPrice := range gasPrices {
+		tx, _ := SignTx(NewTransaction(uint64(i), common.Address{byte(i)}, big.NewInt(100), 100, big.NewInt(gasPrice), nil), signer, key)
+		txs = append(txs, tx)
+	}
+
+	// Create TxByPrice and initialize as heap
+	sorter := (*TxByPrice)(&txs)
+	heap.Init(sorter)
+
+	// Test Pop operation - should get highest gas price first
+	if sorter.Len() != 4 {
+		t.Fatalf("Expected 4 transactions, got %d", sorter.Len())
+	}
+
+	// Pop highest gas price transaction (should be 500)
+	poppedTx := heap.Pop(sorter).(*Transaction)
+	if poppedTx.GasPrice().Int64() != 500 {
+		t.Errorf("Expected to pop transaction with gas price 500, got %d", poppedTx.GasPrice().Int64())
+	}
+
+	// Pop next highest (should be 300)
+	poppedTx = heap.Pop(sorter).(*Transaction)
+	if poppedTx.GasPrice().Int64() != 300 {
+		t.Errorf("Expected to pop transaction with gas price 300, got %d", poppedTx.GasPrice().Int64())
+	}
+
+	// Test Push operation - add a new high-priority transaction
+	newHighTx, _ := SignTx(NewTransaction(10, common.Address{10}, big.NewInt(100), 100, big.NewInt(800), nil), signer, key)
+	heap.Push(sorter, newHighTx)
+
+	// The new transaction should be at the top
+	poppedTx = heap.Pop(sorter).(*Transaction)
+	if poppedTx.GasPrice().Int64() != 800 {
+		t.Errorf("Expected to pop new transaction with gas price 800, got %d", poppedTx.GasPrice().Int64())
+	}
+
+	// Test Push operation - add a low-priority transaction
+	newLowTx, _ := SignTx(NewTransaction(11, common.Address{11}, big.NewInt(100), 100, big.NewInt(50), nil), signer, key)
+	heap.Push(sorter, newLowTx)
+
+	// Should still get the remaining higher priority transactions first
+	remainingPrices := []int64{200, 100, 50}
+	for _, expectedPrice := range remainingPrices {
+		poppedTx = heap.Pop(sorter).(*Transaction)
+		if poppedTx.GasPrice().Int64() != expectedPrice {
+			t.Errorf("Expected to pop transaction with gas price %d, got %d", expectedPrice, poppedTx.GasPrice().Int64())
+		}
+	}
+
+	// Heap should be empty now
+	if sorter.Len() != 0 {
+		t.Errorf("Expected empty heap, got %d transactions", sorter.Len())
+	}
+}
+
+// TestTxByPriceStableSorting tests that transactions with equal gas prices
+// maintain their relative order (stable sorting behavior).
+func TestTxByPriceStableSorting(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	signer := HomesteadSigner{}
+
+	// Create multiple transactions with the same gas price but different nonces
+	sameGasPrice := big.NewInt(250)
+	var txs Transactions
+
+	// Create 5 transactions with the same gas price
+	for i := 0; i < 5; i++ {
+		tx, _ := SignTx(NewTransaction(uint64(i), common.Address{byte(i)}, big.NewInt(100), 100, sameGasPrice, nil), signer, key)
+		txs = append(txs, tx)
+	}
+
+	// Add one high and one low gas price transaction for reference
+	highTx, _ := SignTx(NewTransaction(100, common.Address{100}, big.NewInt(100), 100, big.NewInt(500), nil), signer, key)
+	lowTx, _ := SignTx(NewTransaction(101, common.Address{101}, big.NewInt(100), 100, big.NewInt(100), nil), signer, key)
+
+	// Insert them in the middle to test sorting
+	txs = append(txs[:2], append(Transactions{highTx}, txs[2:]...)...)
+	txs = append(txs[:4], append(Transactions{lowTx}, txs[4:]...)...)
+
+	// Create sorter and sort
+	sorter := (*TxByPrice)(&txs)
+	sort.Sort(sorter)
+
+	// Verify structure: [500] [250, 250, 250, 250, 250] [100]
+	expectedStructure := []int64{500, 250, 250, 250, 250, 250, 100}
+
+	if len(*sorter) != len(expectedStructure) {
+		t.Fatalf("Expected %d transactions, got %d", len(expectedStructure), len(*sorter))
+	}
+
+	for i, expectedPrice := range expectedStructure {
+		actualPrice := (*sorter)[i].GasPrice().Int64()
+		if actualPrice != expectedPrice {
+			t.Errorf("Transaction at index %d: expected gas price %d, got %d", i, expectedPrice, actualPrice)
+		}
+	}
+
+	// Verify that equal gas price transactions maintain some consistent order
+	equalPriceSection := (*sorter)[1:6] // The 5 transactions with gas price 250
+	for i := 0; i < len(equalPriceSection)-1; i++ {
+		if equalPriceSection[i].GasPrice().Cmp(equalPriceSection[i+1].GasPrice()) != 0 {
+			t.Errorf("Equal gas price section has inconsistent prices: %v vs %v",
+				equalPriceSection[i].GasPrice(), equalPriceSection[i+1].GasPrice())
 		}
 	}
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -320,7 +320,7 @@ func (self *worker) update() {
 				acc, _ := types.Sender(self.current.signer, ev.Tx)
 				txs := map[common.Address]types.Transactions{acc: {ev.Tx}}
 				feeCapacity := state.GetTRC21FeeCapacityFromState(self.current.state)
-				txset, specialTxs := types.NewTransactionsByPriceAndNonce(self.current.signer, txs, nil, feeCapacity)
+				txset, specialTxs := types.NewTransactionsByPriceAndNonce(self.current.signer, txs, nil)
 				self.current.commitTransactions(self.mux, feeCapacity, txset, specialTxs, self.chain, self.coinbase)
 				self.updateSnapshot()
 				self.currentMu.Unlock()
@@ -657,7 +657,7 @@ func (self *worker) commitNewWork() {
 			log.Error("Failed to fetch pending transactions", "err", err)
 			return
 		}
-		txs, specialTxs = types.NewTransactionsByPriceAndNonce(self.current.signer, pending, signers, feeCapacity)
+		txs, specialTxs = types.NewTransactionsByPriceAndNonce(self.current.signer, pending, signers)
 	}
 	if atomic.LoadInt32(&self.mining) == 1 {
 		wallet, err := self.eth.AccountManager().Find(accounts.Account{Address: self.coinbase})


### PR DESCRIPTION
### Problem
The transactions should be sort by gas price but if the transaction is VRC25 tx the gas price will be treated as the same price (0.25 Gwei).

### Introduction
This pull request refactors the `TxByPrice` sorting mechanism by simplifying its structure and removing special handling for TRC21 transactions. It also updates the corresponding test cases to ensure correctness and stability of the changes. The most important changes include the removal of `payersSwap` from the `TxByPrice` struct, updates to the sorting logic, and the addition of comprehensive test cases for transaction sorting.

### Refactoring and Simplification:

* **Simplified `TxByPrice` structure**: The `payersSwap` field was removed, and the `TxByPrice` type was redefined as an alias for `Transactions`, eliminating special handling for TRC21 transactions. This simplifies the sorting logic to rely solely on gas prices. (`core/types/transaction.go`) [[1]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L556-R572) [[2]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L608-L611)
* **Updated sorting logic**: Modifications were made to methods like `Less`, `Push`, and `Pop` to align with the simplified `TxByPrice` structure. Sorting now exclusively considers gas prices without any additional conditions. (`core/types/transaction.go`) [[1]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L556-R572) [[2]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L635-R618) [[3]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L652-R645)

### Test Enhancements:

* **New test cases for sorting**: Added multiple test cases to validate the new sorting behavior, including scenarios for stable sorting, heap operations, and handling of transactions with equal gas prices. (`core/types/transaction_test.go`)
* **Removed TRC21-specific test logic**: Updated existing tests to align with the removal of TRC21-specific prioritization, ensuring all transactions are sorted purely by gas price. (`core/types/transaction_test.go`)

### Codebase Updates:

* **Updated function signatures**: Removed the `payersSwap` parameter from the `NewTransactionsByPriceAndNonce` function and updated all its invocations accordingly. (`core/types/transaction.go`, `miner/worker.go`) [[1]](diffhunk://#diff-8fb609018eccff10931645347515b8ecc194992cc4ef9e84ebdea87682dd50c3L608-L611) [[2]](diffhunk://#diff-689874b30f6f905ce6c47cdefeddcf052b467a7936a981f4b6cf38939e10d924L323-R323) [[3]](diffhunk://#diff-689874b30f6f905ce6c47cdefeddcf052b467a7936a981f4b6cf38939e10d924L660-R660)
* **Import adjustments**: Added necessary imports like `container/heap` and `sort` to support the new test cases. (`core/types/transaction_test.go`)