### PR TITLE
Fix Viction always warning when a peer disconnected

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -428,7 +428,7 @@ func (ps *peerSet) Unregister(id string) error {
 	ps.lock.Lock()
 	p, ok := ps.peers[id]
 	if !ok {
-		defer ps.lock.Unlock()
+		ps.lock.Unlock()
 		return errNotRegistered
 	}
 	delete(ps.peers, id)


### PR DESCRIPTION
### Problem
When a peer is disconnected, others peer will always log warning: 
```
WARN [06-26|14:44:12] Failed to unregister sync peer           peer=0342e9c79df72766 err="peer is not registered"
WARN [06-26|14:44:12] Peer removal failed                      peer=0342e9c79df72766 err="peer is not registered"
```
Because of the  `pairPeer` connection. When a peer is connected, another connection called `pairPeer` will be established. It's help split the data transfer through into one for Transactions, Announcements and one for Blocks, Headers, Bodies. 
But when the peer is disconnected, 2 connections will simultaneously unregister the same peer and cause the race condition. 

### Solution 
Introduce a `unregisterMutex` to synchronize unregister peer to prevent race condition. 

### Additional
- Add Unregister peerSet unlock: https://github.com/ethereum/go-ethereum/pull/21227