### PR TITLE
build: support `make lint` and golangci-lint v2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/_vendor/pkg
 
 # used by the Makefile
 /build/_workspace/
+/build/cache/
 /build/bin/
 /tomo*.zip
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,96 @@
+# This file configures github.com/golangci/golangci-lint.
+version: '2'
+run:
+  tests: true
+linters:
+  default: none
+  enable:
+    - bidichk
+    - copyloopvar
+    - durationcheck
+    - gocheckcompilerdirectives
+    - govet
+    - ineffassign
+    - mirror
+    - misspell
+    - reassign
+    - revive # only certain checks enabled
+    - staticcheck
+    - unconvert
+    - unused
+    - usetesting
+    - whitespace
+    ### linters we tried and will not be using:
+    ###
+    # - structcheck # lots of false positives
+    # - errcheck #lot of false positives
+    # - contextcheck
+    # - errchkjson # lots of false positives
+    # - errorlint # this check crashes
+    # - exhaustive # silly check
+    # - makezero # false positives
+    # - nilerr # several intentional
+  settings:
+    staticcheck:
+      checks:
+        # disable Quickfixes
+        - -QF1*
+    revive:
+      enable-all-rules: false
+      # here we enable specific useful rules
+      # see https://golangci-lint.run/usage/linters/#revive for supported rules
+      rules:
+        - name: receiver-naming
+          severity: warning
+          disabled: false
+          exclude:
+            - ''
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - deadcode
+          - staticcheck
+        path: crypto/bn256/cloudflare/optate.go
+      - linters:
+          - revive
+        path: crypto/bn256/
+      - path: cmd/utils/flags.go
+        text: "SA1019: cfg.TxLookupLimit is deprecated: use 'TransactionHistory' instead."
+      - path: cmd/utils/flags.go
+        text: "SA1019: ethconfig.Defaults.TxLookupLimit is deprecated: use 'TransactionHistory' instead."
+      - path: internal/build/pgp.go
+        text: 'SA1019: "golang.org/x/crypto/openpgp" is deprecated: this package is unmaintained except for security fixes.'
+      - path: core/vm/contracts.go
+        text: 'SA1019: "golang.org/x/crypto/ripemd160" is deprecated: RIPEMD-160 is a legacy hash and should not be used for new applications.'
+      - path: (.+)\.go$
+        text: 'SA1019: event.TypeMux is deprecated: use Feed'
+      - path: (.+)\.go$
+        text: 'SA1019: strings.Title is deprecated'
+      - path: (.+)\.go$
+        text: 'SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.'
+      - path: (.+)\.go$
+        text: 'SA1029: should not use built-in type string as key for value'
+    paths:
+      - core/genesis_alloc.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - core/genesis_alloc.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOBIN = $(shell pwd)/build/bin
 GOFMT = gofmt
 GO ?= 1.18.10
 GO_PACKAGES = .
+GORUN = go run
 GO_FILES := $(shell find $(shell go list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
 
 GIT = git
@@ -35,6 +36,10 @@ all:
 
 test: all
 	go run build/ci.go test
+
+#? lint: Run certain pre-selected linters.
+lint: ## Run linters.
+	$(GORUN) build/ci.go lint
 
 clean:
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,0 +1,33 @@
+# This file contains sha256 checksums of optional build dependencies.
+
+# version:golangci 2.4.0
+# https://github.com/golangci/golangci-lint/releases/
+# https://github.com/golangci/golangci-lint/releases/download/v2.4.0/
+7904ce63f79db44934939cf7a063086ea0ea98e9b19eba0a9d52ccdd0d21951c  golangci-lint-2.4.0-darwin-amd64.tar.gz
+cd4dd53fa09b6646baff5fd22b8c64d91db02c21c7496df27992d75d34feec59  golangci-lint-2.4.0-darwin-arm64.tar.gz
+d58f426ebe14cc257e81562b4bf37a488ffb4ffbbb3ec73041eb3b38bb25c0e1  golangci-lint-2.4.0-freebsd-386.tar.gz
+6ec4a6177fc6c0dd541fbcb3a7612845266d020d35cc6fa92959220cdf64ca39  golangci-lint-2.4.0-freebsd-amd64.tar.gz
+4d473e3e71c01feaa915a0604fb35758b41284fb976cdeac3f842118d9ee7e17  golangci-lint-2.4.0-freebsd-armv6.tar.gz
+58727746c6530801a3f9a702a5945556a5eb7e88809222536dd9f9d54cafaeff  golangci-lint-2.4.0-freebsd-armv7.tar.gz
+fbf28c662760e24c32f82f8d16dffdb4a82de7726a52ba1fad94f890c22997ea  golangci-lint-2.4.0-illumos-amd64.tar.gz
+a15a000a8981ef665e971e0f67e2acda9066a9e37a59344393b7351d8fb49c81  golangci-lint-2.4.0-linux-386.tar.gz
+fae792524c04424c0ac369f5b8076f04b45cf29fc945a370e55d369a8dc11840  golangci-lint-2.4.0-linux-amd64.tar.gz
+70ac11f55b80ec78fd3a879249cc9255121b8dfd7f7ed4fc46ed137f4abf17e7  golangci-lint-2.4.0-linux-arm64.tar.gz
+4acdc40e5cebe99e4e7ced358a05b2e71789f409b41cb4f39bbb86ccfa14b1dc  golangci-lint-2.4.0-linux-armv6.tar.gz
+2a68749568fa22b4a97cb88dbea655595563c795076536aa6c087f7968784bf3  golangci-lint-2.4.0-linux-armv7.tar.gz
+9e3369afb023711036dcb0b4f45c9fe2792af962fa1df050c9f6ac101a6c5d73  golangci-lint-2.4.0-linux-loong64.tar.gz
+bb9143d6329be2c4dbfffef9564078e7da7d88e7dde6c829b6263d98e072229e  golangci-lint-2.4.0-linux-mips64.tar.gz
+5ad1765b40d56cd04d4afd805b3ba6f4bfd9b36181da93c31e9b17e483d8608d  golangci-lint-2.4.0-linux-mips64le.tar.gz
+918936fb9c0d5ba96bef03cf4348b03938634cfcced49be1e9bb29cb5094fa73  golangci-lint-2.4.0-linux-ppc64le.tar.gz
+f7474c638e1fb67ebbdc654b55ca0125377ea0bc88e8fee8d964a4f24eacf828  golangci-lint-2.4.0-linux-riscv64.tar.gz
+b617a9543997c8bfceaffa88a75d4e595030c6add69fba800c1e4d8f5fe253dd  golangci-lint-2.4.0-linux-s390x.tar.gz
+7db027b03a9ba328f795215b04f594036837bc7dd0dd7cd16776b02a6167981c  golangci-lint-2.4.0-netbsd-386.tar.gz
+52d8f9393f4313df0a62b752c37775e3af0b818e43e8dd28954351542d7c60bc  golangci-lint-2.4.0-netbsd-amd64.tar.gz
+5c0086027fb5a4af3829e530c8115db4b35d11afe1914322eef528eb8cd38c69  golangci-lint-2.4.0-netbsd-arm64.tar.gz
+6b779d6ed1aed87cefe195cc11759902b97a76551b593312c6833f2635a3488f  golangci-lint-2.4.0-netbsd-armv6.tar.gz
+f00d1f4b7ec3468a0f9fffd0d9ea036248b029b7621cbc9a59c449ef94356d09  golangci-lint-2.4.0-netbsd-armv7.tar.gz
+3ce671b0b42b58e35066493aab75a7e2826c9e079988f1ba5d814a4029faaf87  golangci-lint-2.4.0-windows-386.zip
+003112f7a56746feaabf20b744054bf9acdf900c9e77176383623c4b1d76aaa9  golangci-lint-2.4.0-windows-amd64.zip
+dc0c2092af5d47fc2cd31a1dfe7b4c7e765fab22de98bd21ef2ffcc53ad9f54f  golangci-lint-2.4.0-windows-arm64.zip
+0263d23e20a260cb1592d35e12a388f99efe2c51b3611fdc66fbd9db1fce664d  golangci-lint-2.4.0-windows-armv6.zip
+9403c03bf648e6313036e0273149d44bad1b9ad53889b6d00e4ccb842ba3c058  golangci-lint-2.4.0-windows-armv7.zip

--- a/internal/build/archive.go
+++ b/internal/build/archive.go
@@ -1,0 +1,135 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package build
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func ExtractArchive(archive string, dest string) error {
+	ar, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer ar.Close()
+
+	switch {
+	case strings.HasSuffix(archive, ".tar.gz"):
+		return extractTarball(ar, dest)
+	case strings.HasSuffix(archive, ".zip"):
+		return extractZip(ar, dest)
+	default:
+		return fmt.Errorf("unhandled archive type %s", archive)
+	}
+}
+
+// extractTarball unpacks a .tar.gz file.
+func extractTarball(ar io.Reader, dest string) error {
+	gzr, err := gzip.NewReader(ar)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		// Move to the next file header.
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		// We only care about regular files, directory modes
+		// and special file types are not supported.
+		if header.Typeflag == tar.TypeReg {
+			armode := header.FileInfo().Mode()
+			err := extractFile(header.Name, armode, tr, dest)
+			if err != nil {
+				return fmt.Errorf("extract %s: %v", header.Name, err)
+			}
+		}
+	}
+}
+
+// extractZip unpacks the given .zip file.
+func extractZip(ar *os.File, dest string) error {
+	info, err := ar.Stat()
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(ar, info.Size())
+	if err != nil {
+		return err
+	}
+
+	for _, zf := range zr.File {
+		if !zf.Mode().IsRegular() {
+			continue
+		}
+
+		data, err := zf.Open()
+		if err != nil {
+			return err
+		}
+		err = extractFile(zf.Name, zf.Mode(), data, dest)
+		data.Close()
+		if err != nil {
+			return fmt.Errorf("extract %s: %v", zf.Name, err)
+		}
+	}
+	return nil
+}
+
+// extractFile extracts a single file from an archive.
+func extractFile(arpath string, armode os.FileMode, data io.Reader, dest string) error {
+	// Check that path is inside destination directory.
+	target := filepath.Join(dest, filepath.FromSlash(arpath))
+	if !strings.HasPrefix(target, filepath.Clean(dest)+string(os.PathSeparator)) {
+		return fmt.Errorf("path %q escapes archive destination", target)
+	}
+
+	// Remove the preivously-extracted file if it exists
+	if err := os.RemoveAll(target); err != nil {
+		return err
+	}
+
+	// Recreate the destination directory
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return err
+	}
+
+	// Copy file data.
+	file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, armode)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(file, data); err != nil {
+		file.Close()
+		os.Remove(target)
+		return err
+	}
+	return file.Close()
+}

--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type GoToolchain struct {
+	Root string // GOROOT
+
+	// Cross-compilation variables. These are set when running the go tool.
+	GOARCH string
+	GOOS   string
+	CC     string
+}
+
+func (g *GoToolchain) Go(command string, args ...string) *exec.Cmd {
+	tool := g.goTool(command, args...)
+
+	// Configure environment for cross build.
+	if g.GOARCH != "" && g.GOARCH != runtime.GOARCH {
+		tool.Env = append(tool.Env, "CGO_ENABLED=1")
+		tool.Env = append(tool.Env, "GOARCH="+g.GOARCH)
+	}
+	if g.GOOS != "" && g.GOOS != runtime.GOOS {
+		tool.Env = append(tool.Env, "GOOS="+g.GOOS)
+	}
+	// Configure C compiler.
+	if g.CC != "" {
+		tool.Env = append(tool.Env, "CC="+g.CC)
+	} else if os.Getenv("CC") != "" {
+		tool.Env = append(tool.Env, "CC="+os.Getenv("CC"))
+	}
+	// CKZG by default is not portable, append the necessary build flags to make
+	// it not rely on modern CPU instructions and enable linking against.
+	tool.Env = append(tool.Env, "CGO_CFLAGS=-O2 -g -D__BLST_PORTABLE__")
+
+	return tool
+}
+
+func (g *GoToolchain) goTool(command string, args ...string) *exec.Cmd {
+	if g.Root == "" {
+		g.Root = runtime.GOROOT()
+	}
+	tool := exec.Command(filepath.Join(g.Root, "bin", "go"), command) // nolint: gosec
+	tool.Args = append(tool.Args, args...)
+	tool.Env = append(tool.Env, "GOROOT="+g.Root)
+
+	// Forward environment variables to the tool, but skip compiler target settings.
+	// TODO: what about GOARM?
+	skip := map[string]struct{}{"GOROOT": {}, "GOARCH": {}, "GOOS": {}, "GOBIN": {}, "CC": {}}
+	for _, e := range os.Environ() {
+		if i := strings.IndexByte(e, '='); i >= 0 {
+			if _, ok := skip[e[:i]]; ok {
+				continue
+			}
+		}
+		tool.Env = append(tool.Env, e)
+	}
+	return tool
+}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -1,0 +1,279 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package download implements checksum-verified file downloads.
+package download
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ChecksumDB keeps file checksums and tool versions.
+type ChecksumDB struct {
+	hashes   []hashEntry
+	versions []versionEntry
+}
+type versionEntry struct {
+	name    string
+	version string
+}
+
+type hashEntry struct {
+	hash string
+	file string
+	url  *url.URL
+}
+
+// MustLoadChecksums loads a file containing checksums.
+func MustLoadChecksums(file string) *ChecksumDB {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		panic("can't load checksum file: " + err.Error())
+	}
+	db, err := ParseChecksums(content)
+	if err != nil {
+		panic(fmt.Sprintf("invalid checksums in %s: %v", file, err))
+	}
+	return db
+}
+
+// ParseChecksums parses a checksum database.
+func ParseChecksums(input []byte) (*ChecksumDB, error) {
+	var (
+		csdb    = new(ChecksumDB)
+		rd      = bytes.NewBuffer(input)
+		lastURL *url.URL
+	)
+	for lineNum := 1; ; lineNum++ {
+		line, err := rd.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+			// Blank lines are allowed, and they reset the current urlEntry.
+			lastURL = nil
+
+		case strings.HasPrefix(line, "#"):
+			// It's a comment. Some comments have special meaning.
+			content := strings.TrimLeft(line, "# ")
+			switch {
+			case strings.HasPrefix(content, "version:"):
+				// Version comments define the version of a tool.
+				v := strings.Split(content, ":")[1]
+				parts := strings.Split(v, " ")
+				if len(parts) != 2 {
+					return nil, fmt.Errorf("line %d: invalid version string: %q", lineNum, v)
+				}
+				csdb.versions = append(csdb.versions, versionEntry{parts[0], parts[1]})
+
+			case strings.HasPrefix(content, "https://") || strings.HasPrefix(content, "http://"):
+				// URL comments define the URL where the following files are found. Here
+				// we keep track of the last found urlEntry and attach it to each file later.
+				u, err := url.Parse(content)
+				if err != nil {
+					return nil, fmt.Errorf("line %d: invalid URL: %v", lineNum, err)
+				}
+				lastURL = u
+			}
+
+		default:
+			// It's a file hash entry.
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("line %d: invalid number of space-separated fields (%d)", lineNum, len(fields))
+			}
+			csdb.hashes = append(csdb.hashes, hashEntry{fields[0], fields[1], lastURL})
+		}
+	}
+	return csdb, nil
+}
+
+// Files returns an iterator over all file names.
+func (db *ChecksumDB) Files() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, e := range db.hashes {
+			if !yield(e.file) {
+				return
+			}
+		}
+	}
+}
+
+func verifyHash(path, expectedHash string) error {
+	fd, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, bufio.NewReader(fd)); err != nil {
+		return err
+	}
+	fileHash := hex.EncodeToString(h.Sum(nil))
+	if fileHash != expectedHash {
+		return fmt.Errorf("invalid file hash: %s %s", fileHash, filepath.Base(path))
+	}
+	return nil
+}
+
+// DownloadFileFromKnownURL downloads a file from the URL defined in the checksum database.
+func (db *ChecksumDB) DownloadFileFromKnownURL(dstPath string) error {
+	base := filepath.Base(dstPath)
+	url, err := db.FindURL(base)
+	if err != nil {
+		return err
+	}
+	return db.DownloadFile(url, dstPath)
+}
+
+// DownloadFile downloads a file and verifies its checksum.
+func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
+	basename := filepath.Base(dstPath)
+	hash := db.findHash(basename)
+	if hash == "" {
+		return fmt.Errorf("no known hash for file %q", basename)
+	}
+	// Shortcut if already downloaded.
+	if verifyHash(dstPath, hash) == nil {
+		fmt.Printf("%s is up-to-date\n", dstPath)
+		return nil
+	}
+
+	fmt.Printf("%s is stale\n", dstPath)
+	fmt.Printf("downloading from %s\n", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("download error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download error: status %d", resp.StatusCode)
+	}
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+		return err
+	}
+
+	// Download to a temporary file.
+	tmpfile := dstPath + ".tmp"
+	fd, err := os.OpenFile(tmpfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	dst := newDownloadWriter(fd, resp.ContentLength)
+	_, err = io.Copy(dst, resp.Body)
+	dst.Close()
+	if err != nil {
+		os.Remove(tmpfile)
+		return err
+	}
+	if err := verifyHash(tmpfile, hash); err != nil {
+		os.Remove(tmpfile)
+		return err
+	}
+	// It's valid, rename to dstPath to complete the download.
+	return os.Rename(tmpfile, dstPath)
+}
+
+// findHash returns the known hash of a file.
+func (db *ChecksumDB) findHash(basename string) string {
+	for _, e := range db.hashes {
+		if e.file == basename {
+			return e.hash
+		}
+	}
+	return ""
+}
+
+// FindVersion returns the current known version of a tool, if it is defined in the file.
+func (db *ChecksumDB) FindVersion(tool string) (string, error) {
+	for _, e := range db.versions {
+		if e.name == tool {
+			return e.version, nil
+		}
+	}
+	return "", fmt.Errorf("tool version %q not defined in checksum database", tool)
+}
+
+// FindURL gets the URL for a file.
+func (db *ChecksumDB) FindURL(basename string) (string, error) {
+	for _, e := range db.hashes {
+		if e.file == basename {
+			if e.url == nil {
+				return "", fmt.Errorf("file %q has no URL defined", e.file)
+			}
+			return e.url.JoinPath(e.file).String(), nil
+		}
+	}
+	return "", fmt.Errorf("file %q does not exist in checksum database", basename)
+}
+
+type downloadWriter struct {
+	file    *os.File
+	dstBuf  *bufio.Writer
+	size    int64
+	written int64
+	lastpct int64
+}
+
+func newDownloadWriter(dst *os.File, size int64) *downloadWriter {
+	return &downloadWriter{
+		file:   dst,
+		dstBuf: bufio.NewWriter(dst),
+		size:   size,
+	}
+}
+
+func (w *downloadWriter) Write(buf []byte) (int, error) {
+	n, err := w.dstBuf.Write(buf)
+
+	// Report progress.
+	w.written += int64(n)
+	pct := w.written * 10 / w.size * 10
+	if pct != w.lastpct {
+		if w.lastpct != 0 {
+			fmt.Print("...")
+		}
+		fmt.Print(pct, "%")
+		w.lastpct = pct
+	}
+	return n, err
+}
+
+func (w *downloadWriter) Close() error {
+	if w.lastpct > 0 {
+		fmt.Println() // Finish the progress line.
+	}
+	flushErr := w.dstBuf.Flush()
+	closeErr := w.file.Close()
+	if flushErr != nil {
+		return flushErr
+	}
+	return closeErr
+}


### PR DESCRIPTION
- implement `make lint`
- support golangci-lint v2.4.0
