### PR TITLE
Implement bypass for blacklist balance during tracing

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -474,6 +475,8 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, tomoxState, api.config, vm.Config{})
+		// Mirror the on-chain blacklist balance bypass
+		bypassBlacklistBalance(statedb, block.Number(), msg.From())
 		owner := common.Address{}
 		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
 			failed = err
@@ -598,6 +601,155 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 	return api.traceTx(ctx, msg, vmctx, statedb, config)
 }
 
+// bypassBlacklistBalance mirrors the "Bypass blacklist address" workaround in
+// core.ApplyTransaction. During real block processing that code restores the
+// balance of a fixed set of accounts at specific historical blocks so their
+// transactions can be executed. Tracing calls vm.ApplyMessage directly and
+// therefore skips that path, causing "insufficient funds" errors when replaying
+// the affected transactions. This helper re-applies the exact same balance
+// injection before an off-chain ApplyMessage. It only touches the trace's
+// in-memory state and never affects consensus.
+func bypassBlacklistBalance(statedb *state.StateDB, blockNumber *big.Int, from common.Address) {
+	maxBlockNumber := new(big.Int).SetInt64(9147459)
+	if blockNumber.Cmp(maxBlockNumber) > 0 {
+		return
+	}
+	addrMap := make(map[string]string)
+	addrMap["0x5248bfb72fd4f234e062d3e9bb76f08643004fcd"] = "29410"
+	addrMap["0x5ac26105b35ea8935be382863a70281ec7a985e9"] = "23551"
+	addrMap["0x09c4f991a41e7ca0645d7dfbfee160b55e562ea4"] = "25821"
+	addrMap["0xb3157bbc5b401a45d6f60b106728bb82ebaa585b"] = "20051"
+	addrMap["0x741277a8952128d5c2ffe0550f5001e4c8247674"] = "23937"
+	addrMap["0x10ba49c1caa97d74b22b3e74493032b180cebe01"] = "27320"
+	addrMap["0x07048d51d9e6179578a6e3b9ee28cdc183b865e4"] = "29758"
+	addrMap["0x4b899001d73c7b4ec404a771d37d9be13b8983de"] = "26148"
+	addrMap["0x85cb320a9007f26b7652c19a2a65db1da2d0016f"] = "27216"
+	addrMap["0x06869dbd0e3a2ea37ddef832e20fa005c6f0ca39"] = "29449"
+	addrMap["0x82e48bc7e2c93d89125428578fb405947764ad7c"] = "28084"
+	addrMap["0x1f9a78534d61732367cbb43fc6c89266af67c989"] = "29287"
+	addrMap["0x7c3b1fa91df55ff7af0cad9e0399384dc5c6641b"] = "21574"
+	addrMap["0x5888dc1ceb0ff632713486b9418e59743af0fd20"] = "28836"
+	addrMap["0xa512fa1c735fc3cc635624d591dd9ea1ce339ca5"] = "25515"
+	addrMap["0x0832517654c7b7e36b1ef45d76de70326b09e2c7"] = "22873"
+	addrMap["0xca14e3c4c78bafb60819a78ff6e6f0f709d2aea7"] = "24968"
+	addrMap["0x652ce195a23035114849f7642b0e06647d13e57a"] = "24091"
+	addrMap["0x29a79f00f16900999d61b6e171e44596af4fb5ae"] = "20790"
+	addrMap["0xf9fd1c2b0af0d91b0b6754e55639e3f8478dd04a"] = "23331"
+	addrMap["0xb835710c9901d5fe940ef1b99ed918902e293e35"] = "28273"
+	addrMap["0x04dd29ce5c253377a9a3796103ea0d9a9e514153"] = "29956"
+	addrMap["0x2b4b56846eaf05c1fd762b5e1ac802efd0ab871c"] = "24911"
+	addrMap["0x1d1f909f6600b23ce05004f5500ab98564717996"] = "25637"
+	addrMap["0x0dfdcebf80006dc9ab7aae8c216b51c6b6759e86"] = "26378"
+	addrMap["0x2b373890a28e5e46197fbc04f303bbfdd344056f"] = "21109"
+	addrMap["0xa8a3ef3dc5d8e36aee76f3671ec501ec31e28254"] = "22072"
+	addrMap["0x4f3d18136fe2b5665c29bdaf74591fc6625ef427"] = "21650"
+	addrMap["0x175d728b0e0f1facb5822a2e0c03bde93596e324"] = "21588"
+	addrMap["0xd575c2611984fcd79513b80ab94f59dc5bab4916"] = "28971"
+	addrMap["0x0579337873c97c4ba051310236ea847f5be41bc0"] = "28344"
+	addrMap["0xed12a519cc15b286920fc15fd86106b3e6a16218"] = "24443"
+	addrMap["0x492d26d852a0a0a2982bb40ec86fe394488c419e"] = "26623"
+	addrMap["0xce5c7635d02dc4e1d6b46c256cae6323be294a32"] = "28459"
+	addrMap["0x8b94db158b5e78a6c032c7e7c9423dec62c8b11c"] = "21803"
+	addrMap["0x0e7c48c085b6b0aa7ca6e4cbcc8b9a92dc270eb4"] = "21739"
+	addrMap["0x206e6508462033ef8425edc6c10789d241d49acb"] = "21883"
+	addrMap["0x7710e7b7682f26cb5a1202e1cff094fbf7777758"] = "28907"
+	addrMap["0xcb06f949313b46bbf53b8e6b2868a0c260ff9385"] = "28932"
+	addrMap["0xf884e43533f61dc2997c0e19a6eff33481920c00"] = "27780"
+	addrMap["0x8b635ef2e4c8fe21fc2bda027eb5f371d6aa2fc1"] = "23115"
+	addrMap["0x10f01a27cf9b29d02ce53497312b96037357a361"] = "22716"
+	addrMap["0x693dd49b0ed70f162d733cf20b6c43dc2a2b4d95"] = "20020"
+	addrMap["0xe0bec72d1c2a7a7fb0532cdfac44ebab9f6f41ee"] = "23071"
+	addrMap["0xc8793633a537938cb49cdbbffd45428f10e45b64"] = "24652"
+	addrMap["0x0d07a6cbbe9fa5c4f154e5623bfe47fb4d857d8e"] = "21907"
+	addrMap["0xd4080b289da95f70a586610c38268d8d4cf1e4c4"] = "22719"
+	addrMap["0x8bcfb0caf41f0aa1b548cae76dcdd02e33866a1b"] = "29062"
+	addrMap["0xabfef22b92366d3074676e77ea911ccaabfb64c1"] = "23110"
+	addrMap["0xcc4df7a32faf3efba32c9688def5ccf9fefe443d"] = "21397"
+	addrMap["0x7ec1e48a582475f5f2b7448a86c4ea7a26ea36f8"] = "23105"
+	addrMap["0xe3de67289080f63b0c2612844256a25bb99ac0ad"] = "29721"
+	addrMap["0x3ba623300cf9e48729039b3c9e0dee9b785d636e"] = "25917"
+	addrMap["0x402f2cfc9c8942f5e7a12c70c625d07a5d52fe29"] = "24712"
+	addrMap["0xd62358d42afbde095a4ca868581d85f9adcc3d61"] = "24449"
+	addrMap["0x3969f86acb733526cd61e3c6e3b4660589f32bc6"] = "29579"
+	addrMap["0x67615413d7cdadb2c435a946aec713a9a9794d39"] = "26333"
+	addrMap["0xfe685f43acc62f92ab01a8da80d76455d39d3cb3"] = "29825"
+	addrMap["0x3538a544021c07869c16b764424c5987409cba48"] = "22746"
+	addrMap["0xe187cf86c2274b1f16e8225a7da9a75aba4f1f5f"] = "23734"
+
+	blockMap := make(map[int64]string)
+	blockMap[9073579] = "0x5248bfb72fd4f234e062d3e9bb76f08643004fcd"
+	blockMap[9147130] = "0x5ac26105b35ea8935be382863a70281ec7a985e9"
+	blockMap[9147195] = "0x09c4f991a41e7ca0645d7dfbfee160b55e562ea4"
+	blockMap[9147200] = "0xb3157bbc5b401a45d6f60b106728bb82ebaa585b"
+	blockMap[9147206] = "0x741277a8952128d5c2ffe0550f5001e4c8247674"
+	blockMap[9147212] = "0x10ba49c1caa97d74b22b3e74493032b180cebe01"
+	blockMap[9147217] = "0x07048d51d9e6179578a6e3b9ee28cdc183b865e4"
+	blockMap[9147223] = "0x4b899001d73c7b4ec404a771d37d9be13b8983de"
+	blockMap[9147229] = "0x85cb320a9007f26b7652c19a2a65db1da2d0016f"
+	blockMap[9147234] = "0x06869dbd0e3a2ea37ddef832e20fa005c6f0ca39"
+	blockMap[9147240] = "0x82e48bc7e2c93d89125428578fb405947764ad7c"
+	blockMap[9147246] = "0x1f9a78534d61732367cbb43fc6c89266af67c989"
+	blockMap[9147251] = "0x7c3b1fa91df55ff7af0cad9e0399384dc5c6641b"
+	blockMap[9147257] = "0x5888dc1ceb0ff632713486b9418e59743af0fd20"
+	blockMap[9147263] = "0xa512fa1c735fc3cc635624d591dd9ea1ce339ca5"
+	blockMap[9147268] = "0x0832517654c7b7e36b1ef45d76de70326b09e2c7"
+	blockMap[9147274] = "0xca14e3c4c78bafb60819a78ff6e6f0f709d2aea7"
+	blockMap[9147279] = "0x652ce195a23035114849f7642b0e06647d13e57a"
+	blockMap[9147285] = "0x29a79f00f16900999d61b6e171e44596af4fb5ae"
+	blockMap[9147291] = "0xf9fd1c2b0af0d91b0b6754e55639e3f8478dd04a"
+	blockMap[9147296] = "0xb835710c9901d5fe940ef1b99ed918902e293e35"
+	blockMap[9147302] = "0x04dd29ce5c253377a9a3796103ea0d9a9e514153"
+	blockMap[9147308] = "0x2b4b56846eaf05c1fd762b5e1ac802efd0ab871c"
+	blockMap[9147314] = "0x1d1f909f6600b23ce05004f5500ab98564717996"
+	blockMap[9147319] = "0x0dfdcebf80006dc9ab7aae8c216b51c6b6759e86"
+	blockMap[9147325] = "0x2b373890a28e5e46197fbc04f303bbfdd344056f"
+	blockMap[9147330] = "0xa8a3ef3dc5d8e36aee76f3671ec501ec31e28254"
+	blockMap[9147336] = "0x4f3d18136fe2b5665c29bdaf74591fc6625ef427"
+	blockMap[9147342] = "0x175d728b0e0f1facb5822a2e0c03bde93596e324"
+	blockMap[9145281] = "0xd575c2611984fcd79513b80ab94f59dc5bab4916"
+	blockMap[9145315] = "0x0579337873c97c4ba051310236ea847f5be41bc0"
+	blockMap[9145341] = "0xed12a519cc15b286920fc15fd86106b3e6a16218"
+	blockMap[9145367] = "0x492d26d852a0a0a2982bb40ec86fe394488c419e"
+	blockMap[9145386] = "0xce5c7635d02dc4e1d6b46c256cae6323be294a32"
+	blockMap[9145414] = "0x8b94db158b5e78a6c032c7e7c9423dec62c8b11c"
+	blockMap[9145436] = "0x0e7c48c085b6b0aa7ca6e4cbcc8b9a92dc270eb4"
+	blockMap[9145463] = "0x206e6508462033ef8425edc6c10789d241d49acb"
+	blockMap[9145493] = "0x7710e7b7682f26cb5a1202e1cff094fbf7777758"
+	blockMap[9145519] = "0xcb06f949313b46bbf53b8e6b2868a0c260ff9385"
+	blockMap[9145549] = "0xf884e43533f61dc2997c0e19a6eff33481920c00"
+	blockMap[9147352] = "0x8b635ef2e4c8fe21fc2bda027eb5f371d6aa2fc1"
+	blockMap[9147357] = "0x10f01a27cf9b29d02ce53497312b96037357a361"
+	blockMap[9147363] = "0x693dd49b0ed70f162d733cf20b6c43dc2a2b4d95"
+	blockMap[9147369] = "0xe0bec72d1c2a7a7fb0532cdfac44ebab9f6f41ee"
+	blockMap[9147375] = "0xc8793633a537938cb49cdbbffd45428f10e45b64"
+	blockMap[9147380] = "0x0d07a6cbbe9fa5c4f154e5623bfe47fb4d857d8e"
+	blockMap[9147386] = "0xd4080b289da95f70a586610c38268d8d4cf1e4c4"
+	blockMap[9147392] = "0x8bcfb0caf41f0aa1b548cae76dcdd02e33866a1b"
+	blockMap[9147397] = "0xabfef22b92366d3074676e77ea911ccaabfb64c1"
+	blockMap[9147403] = "0xcc4df7a32faf3efba32c9688def5ccf9fefe443d"
+	blockMap[9147408] = "0x7ec1e48a582475f5f2b7448a86c4ea7a26ea36f8"
+	blockMap[9147414] = "0xe3de67289080f63b0c2612844256a25bb99ac0ad"
+	blockMap[9147420] = "0x3ba623300cf9e48729039b3c9e0dee9b785d636e"
+	blockMap[9147425] = "0x402f2cfc9c8942f5e7a12c70c625d07a5d52fe29"
+	blockMap[9147431] = "0xd62358d42afbde095a4ca868581d85f9adcc3d61"
+	blockMap[9147437] = "0x3969f86acb733526cd61e3c6e3b4660589f32bc6"
+	blockMap[9147442] = "0x67615413d7cdadb2c435a946aec713a9a9794d39"
+	blockMap[9147448] = "0xfe685f43acc62f92ab01a8da80d76455d39d3cb3"
+	blockMap[9147453] = "0x3538a544021c07869c16b764424c5987409cba48"
+	blockMap[9147459] = "0xe187cf86c2274b1f16e8225a7da9a75aba4f1f5f"
+
+	addrFrom := from.Hex()
+	if addr, ok := blockMap[blockNumber.Int64()]; ok {
+		if strings.ToLower(addr) == strings.ToLower(addrFrom) {
+			bal := addrMap[addr]
+			hBalance := new(big.Int)
+			hBalance.SetString(bal+"000000000000000000", 10)
+			log.Info("address", addr, "with_balance", bal, "TOMO")
+			statedb.SetBalance(common.HexToAddress(addr), hBalance)
+		}
+	}
+}
+
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
@@ -636,6 +788,9 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	}
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, nil, api.config, vm.Config{Debug: true, Tracer: tracer})
+
+	// Mirror the on-chain blacklist balance bypass.
+	bypassBlacklistBalance(statedb, vmctx.BlockNumber, message.From())
 
 	owner := common.Address{}
 	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), owner)


### PR DESCRIPTION
This PR introduces a workaround to the tracing logic in `eth/api_tracer.go` to ensure that certain blacklisted addresses have their balances correctly set when tracing historical transactions. This mirrors a balance restoration mechanism present in on-chain block processing, preventing "insufficient funds" errors when replaying affected transactions during off-chain tracing.
